### PR TITLE
test: add missing nutrition command test coverage

### DIFF
--- a/internal/cmd/nutrition_test.go
+++ b/internal/cmd/nutrition_test.go
@@ -47,6 +47,13 @@ func TestExecute_NutritionMealsHelp(t *testing.T) {
 	}
 }
 
+func TestExecute_NutritionSettingsHelp(t *testing.T) {
+	code := Execute([]string{"nutrition", "settings", "--help"}, "1.0.0", "abc123", "2024-01-01")
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}
+
 func TestNutritionFoodLog_NoAccount(t *testing.T) {
 	var buf bytes.Buffer
 	g := testGlobals(t, &buf, outfmt.Table, "")
@@ -57,6 +64,24 @@ func TestNutritionFoodLog_NoAccount(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no account specified") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNutritionFoodLog_InvalidDate(t *testing.T) {
+	server := nutritionTestServer(t)
+	defer server.Close()
+
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	overrideNewClient(t, server)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.JSON, "test@example.com")
+	cmd := &NutritionFoodLogCmd{Date: "not-a-date"}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }
 
@@ -77,6 +102,46 @@ func TestNutritionFoodLog_Success(t *testing.T) {
 	err := cmd.Run(g)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestNutritionFoodLog_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/nutrition-service/food/logs/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("error"))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	overrideNewClient(t, server)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	overrideNowFn(t, time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC))
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.JSON, "test@example.com")
+	cmd := &NutritionFoodLogCmd{}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// --- NutritionMealsCmd tests ---
+
+func TestNutritionMeals_NoAccount(t *testing.T) {
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "")
+	cmd := &NutritionMealsCmd{}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no account specified") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -108,6 +173,46 @@ func TestNutritionMeals_WithDate(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("expected API to be called")
+	}
+}
+
+func TestNutritionMeals_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/nutrition-service/meals/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("error"))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	overrideNewClient(t, server)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	overrideNowFn(t, time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC))
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.JSON, "test@example.com")
+	cmd := &NutritionMealsCmd{}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// --- NutritionSettingsCmd tests ---
+
+func TestNutritionSettings_NoAccount(t *testing.T) {
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "")
+	cmd := &NutritionSettingsCmd{}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no account specified") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds missing test coverage for the nutrition commands introduced in #36
- Aligns nutrition test coverage with the established hydration test patterns

### Added tests
- `TestExecute_NutritionSettingsHelp` — help output for settings subcommand
- `TestNutritionFoodLog_InvalidDate` — invalid date input handling
- `TestNutritionFoodLog_ServerError` — server error propagation
- `TestNutritionMeals_NoAccount` — no account error path
- `TestNutritionMeals_ServerError` — server error propagation
- `TestNutritionSettings_NoAccount` — no account error path

## Test plan

- [x] `make ci` passes (fmt, lint, test)