### PR TITLE
Add AUR package update trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,3 +67,26 @@ jobs:
             --field repository=bpauli/gccli
         env:
           GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+
+  update-aur:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger aur-packages update
+        run: |
+          gh workflow run update-package.yml \
+            --repo bpauli/aur-packages \
+            --field package=gccli-bin \
+            --field tag=${{ steps.tag.outputs.tag }} \
+            --field repository=bpauli/gccli
+        env:
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `update-aur` job to the release workflow, parallel to the existing `update-homebrew` job
- On release, triggers the `update-package.yml` workflow in `bpauli/aur-packages` to update the `gccli-bin` AUR package
- Supports both tag-push and manual `workflow_dispatch` triggers

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Trigger a test release and confirm both `update-homebrew` and `update-aur` jobs run successfully