### PR TITLE
fix(auth): exchange SSO tickets for DI OAuth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Help:
 gccli auth login you@example.com
 ```
 
-This opens your browser for Garmin SSO authentication. The OAuth tokens are stored securely in your system keyring.
+This opens your browser for Garmin SSO authentication. The DI OAuth tokens are stored securely in your system keyring.
 
 ### 2. Log In (Headless)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -842,7 +842,7 @@ gccli activity download "$latest" --format fit</pre>
         <div class="arch-grid">
           <div class="arch-card fade-in"><h4>internal/cmd/</h4><p>Kong-based CLI commands. Each command is a struct with <code>Run(g *Globals) error</code>.</p></div>
           <div class="arch-card fade-in"><h4>internal/garminapi/</h4><p>HTTP client returning <code>json.RawMessage</code>. RetryTransport + CircuitBreaker.</p></div>
-          <div class="arch-card fade-in"><h4>internal/garminauth/</h4><p>SSO auth: browser + headless login, OAuth1&rarr;OAuth2 exchange, MFA.</p></div>
+          <div class="arch-card fade-in"><h4>internal/garminauth/</h4><p>SSO auth: browser + headless login, DI OAuth exchange, MFA.</p></div>
           <div class="arch-card fade-in"><h4>internal/secrets/</h4><p>OS keyring abstraction. macOS Keychain, Linux Secret Service, file fallback.</p></div>
           <div class="arch-card fade-in"><h4>internal/config/</h4><p>Config file paths and environment variable overrides.</p></div>
           <div class="arch-card fade-in"><h4>internal/outfmt/</h4><p>Output formatting: JSON, Table, and Plain/TSV modes via context.</p></div>

--- a/internal/cmd/client.go
+++ b/internal/cmd/client.go
@@ -21,7 +21,7 @@ func defaultNewClient(tokens *garminauth.Tokens) *garminapi.Client {
 var proactiveRefreshFn = garminauth.RefreshOAuth2
 
 // resolveClient loads stored tokens for the account and returns an API client.
-// If the stored token is already expired and OAuth1 credentials are available,
+// If the stored token is already expired and refresh credentials are available,
 // it proactively refreshes the token before creating the client to avoid
 // a wasted 401 round-trip. Refreshed tokens are persisted back to the keyring.
 func resolveClient(g *Globals) (*garminapi.Client, error) {
@@ -50,7 +50,7 @@ func resolveClient(g *Globals) (*garminapi.Client, error) {
 
 	// Proactive refresh: if the token is already expired, refresh before
 	// creating the client to avoid a wasted 401 round-trip.
-	if tokens.IsExpired() && tokens.HasOAuth1() {
+	if tokens.IsExpired() && tokens.CanRefresh() {
 		newTokens, refreshErr := proactiveRefreshFn(g.Context, tokens, garminauth.LoginOptions{
 			Domain: tokens.Domain,
 		})

--- a/internal/e2e/auth_export_import_test.go
+++ b/internal/e2e/auth_export_import_test.go
@@ -35,6 +35,7 @@ func TestAuthExportImport(t *testing.T) {
 		original.OAuth1Secret,
 		original.OAuth2AccessToken,
 		original.OAuth2RefreshToken,
+		original.DIClientID,
 	} {
 		if secret == "" {
 			continue
@@ -58,10 +59,9 @@ func TestAuthExportImport(t *testing.T) {
 	// Verify all fields round-trip correctly without logging actual values.
 	assertFieldEqual(t, "Email", imported.Email, original.Email)
 	assertFieldEqual(t, "Domain", imported.Domain, original.Domain)
-	assertFieldNonEmpty(t, "OAuth1Token", imported.OAuth1Token)
-	assertFieldNonEmpty(t, "OAuth1Secret", imported.OAuth1Secret)
 	assertFieldNonEmpty(t, "OAuth2AccessToken", imported.OAuth2AccessToken)
 	assertFieldNonEmpty(t, "OAuth2RefreshToken", imported.OAuth2RefreshToken)
+	assertFieldNonEmpty(t, "DIClientID", imported.DIClientID)
 
 	if !imported.OAuth2ExpiresAt.Equal(original.OAuth2ExpiresAt) {
 		t.Error("OAuth2ExpiresAt mismatch after round-trip")

--- a/internal/e2e/auth_test.go
+++ b/internal/e2e/auth_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/bpauli/gccli/internal/garminauth"
 )
 
-// TestHeadlessLogin verifies that headless SSO login returns valid tokens
-// with all expected fields populated.
+// TestHeadlessLogin verifies that headless SSO login returns valid DI OAuth
+// tokens with all expected fields populated.
 func TestHeadlessLogin(t *testing.T) {
 	email, password := LoadEnv(t)
 
@@ -35,12 +35,9 @@ func TestHeadlessLogin(t *testing.T) {
 		t.Error("expected non-empty OAuth2RefreshToken")
 	}
 
-	// Verify OAuth1 credentials are present (needed for token refresh).
-	if tokens.OAuth1Token == "" {
-		t.Error("expected non-empty OAuth1Token")
-	}
-	if tokens.OAuth1Secret == "" {
-		t.Error("expected non-empty OAuth1Secret")
+	// Verify the DI client id is present (needed for refresh_token grants).
+	if tokens.DIClientID == "" {
+		t.Error("expected non-empty DIClientID")
 	}
 }
 

--- a/internal/garminapi/client.go
+++ b/internal/garminapi/client.go
@@ -185,10 +185,10 @@ func (c *Client) doDownload(ctx context.Context, path string, canRetry bool) ([]
 	return data, nil
 }
 
-// refreshToken attempts to refresh the OAuth2 token using stored OAuth1 credentials.
+// refreshToken attempts to refresh the OAuth2 token using stored refresh credentials.
 func (c *Client) refreshToken(ctx context.Context) error {
-	if !c.tokens.HasOAuth1() {
-		return fmt.Errorf("no OAuth1 credentials for refresh")
+	if !c.tokens.CanRefresh() {
+		return fmt.Errorf("no refresh credentials available")
 	}
 
 	newTokens, err := refreshTokensFn(ctx, c.tokens, garminauth.LoginOptions{

--- a/internal/garminapi/client_test.go
+++ b/internal/garminapi/client_test.go
@@ -646,18 +646,19 @@ func TestInvalidFileFormatError(t *testing.T) {
 
 // --- RefreshToken tests ---
 
-func TestRefreshToken_NoOAuth1(t *testing.T) {
+func TestRefreshToken_NoRefreshCredentials(t *testing.T) {
 	tokens := testTokens()
 	tokens.OAuth1Token = ""
 	tokens.OAuth1Secret = ""
+	tokens.OAuth2RefreshToken = ""
 	client := NewClient(tokens)
 
 	err := client.refreshToken(context.Background())
 	if err == nil {
-		t.Fatal("expected error when no OAuth1 credentials")
+		t.Fatal("expected error when no refresh credentials")
 	}
-	if !strings.Contains(err.Error(), "no OAuth1 credentials") {
-		t.Errorf("error = %q, want to contain 'no OAuth1 credentials'", err.Error())
+	if !strings.Contains(err.Error(), "no refresh credentials") {
+		t.Errorf("error = %q, want to contain 'no refresh credentials'", err.Error())
 	}
 }
 

--- a/internal/garminauth/di.go
+++ b/internal/garminauth/di.go
@@ -1,0 +1,203 @@
+package garminauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultDITokenURL = "https://diauth.garmin.com/di-oauth2-service/oauth/token"
+	diGrantType       = "https://connectapi.garmin.com/di-oauth2-service/oauth/grant/service_ticket"
+
+	nativeAPIUserAgent = "GCM-Android-5.23"
+	nativeGarminUA     = "com.garmin.android.apps.connectmobile/5.23; ; Google/sdk_gphone64_arm64/google; Android/33; Dalvik/2.1.0"
+)
+
+var diClientIDs = []string{
+	"GARMIN_CONNECT_MOBILE_ANDROID_DI_2025Q2",
+	"GARMIN_CONNECT_MOBILE_ANDROID_DI_2024Q4",
+	"GARMIN_CONNECT_MOBILE_ANDROID_DI",
+	"GARMIN_CONNECT_MOBILE_IOS_DI",
+}
+
+var diTokenURL = defaultDITokenURL
+
+type diTokenResponse struct {
+	TokenType             string `json:"token_type"`
+	AccessToken           string `json:"access_token"`
+	RefreshToken          string `json:"refresh_token"`
+	ExpiresIn             int    `json:"expires_in"`
+	RefreshTokenExpiresIn int    `json:"refresh_token_expires_in"`
+}
+
+// exchangeServiceTicket exchanges a Garmin CAS service ticket for DI OAuth
+// Bearer tokens. serviceURL must match the service URL used to issue ticket.
+func exchangeServiceTicket(ctx context.Context, client *http.Client, ticket, serviceURL string) (*Tokens, error) {
+	var failures []string
+
+	for _, clientID := range diClientIDs {
+		values := url.Values{
+			"client_id":      {clientID},
+			"service_ticket": {ticket},
+			"grant_type":     {diGrantType},
+			"service_url":    {serviceURL},
+		}
+
+		resp, err := postDIForm(ctx, client, clientID, values)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", clientID, err))
+			continue
+		}
+
+		tokens := tokensFromDIResponse(resp, clientID)
+		tokens.DIClientID = extractClientIDFromJWT(tokens.OAuth2AccessToken, clientID)
+		return tokens, nil
+	}
+
+	return nil, fmt.Errorf("DI token exchange failed for all client ids: %s", strings.Join(failures, "; "))
+}
+
+// refreshDI refreshes DI OAuth Bearer tokens using a stored refresh token.
+func refreshDI(ctx context.Context, client *http.Client, tokens *Tokens) (*Tokens, error) {
+	if tokens.OAuth2RefreshToken == "" {
+		return nil, fmt.Errorf("no DI refresh token available")
+	}
+
+	clientIDs := diClientIDs
+	if tokens.DIClientID != "" {
+		clientIDs = append([]string{tokens.DIClientID}, diClientIDs...)
+	}
+
+	var failures []string
+	for _, clientID := range dedupeStrings(clientIDs) {
+		values := url.Values{
+			"grant_type":    {"refresh_token"},
+			"client_id":     {clientID},
+			"refresh_token": {tokens.OAuth2RefreshToken},
+		}
+
+		resp, err := postDIForm(ctx, client, clientID, values)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", clientID, err))
+			continue
+		}
+
+		refreshed := tokensFromDIResponse(resp, clientID)
+		refreshed.Domain = tokens.Domain
+		refreshed.Email = tokens.Email
+		refreshed.DisplayName = tokens.DisplayName
+		refreshed.MFAToken = tokens.MFAToken
+		refreshed.OAuth1Token = tokens.OAuth1Token
+		refreshed.OAuth1Secret = tokens.OAuth1Secret
+		refreshed.DIClientID = extractClientIDFromJWT(refreshed.OAuth2AccessToken, clientID)
+		if refreshed.OAuth2RefreshToken == "" {
+			refreshed.OAuth2RefreshToken = tokens.OAuth2RefreshToken
+		}
+		return refreshed, nil
+	}
+
+	return nil, fmt.Errorf("DI token refresh failed for all client ids: %s", strings.Join(failures, "; "))
+}
+
+func postDIForm(ctx context.Context, client *http.Client, clientID string, values url.Values) (*diTokenResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, diTokenURL, strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range nativeHeaders() {
+		req.Header.Set(key, value)
+	}
+	req.Header.Set("Authorization", basicAuth(clientID))
+	req.Header.Set("Accept", "application/json,text/html;q=0.9,*/*;q=0.8")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Cache-Control", "no-cache")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var parsed diTokenResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return nil, fmt.Errorf("response missing access_token")
+	}
+	return &parsed, nil
+}
+
+func tokensFromDIResponse(resp *diTokenResponse, clientID string) *Tokens {
+	return &Tokens{
+		OAuth2AccessToken:  resp.AccessToken,
+		OAuth2RefreshToken: resp.RefreshToken,
+		OAuth2ExpiresAt:    time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second),
+		DIClientID:         clientID,
+	}
+}
+
+func nativeHeaders() map[string]string {
+	return map[string]string{
+		"User-Agent":                  nativeAPIUserAgent,
+		"X-Garmin-User-Agent":         nativeGarminUA,
+		"X-Garmin-Paired-App-Version": "10861",
+		"X-Garmin-Client-Platform":    "Android",
+		"X-App-Ver":                   "10861",
+		"X-Lang":                      "en",
+		"X-GCExperience":              "GC5",
+		"Accept-Language":             "en-US,en;q=0.9",
+	}
+}
+
+func basicAuth(clientID string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(clientID+":"))
+}
+
+func extractClientIDFromJWT(token, fallback string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return fallback
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return fallback
+	}
+
+	var claims struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.ClientID == "" {
+		return fallback
+	}
+	return claims.ClientID
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/garminauth/di_test.go
+++ b/internal/garminauth/di_test.go
@@ -1,0 +1,111 @@
+package garminauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRefreshOAuth2_DIRefresh(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /di-oauth2-service/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != basicAuth("test-di-client") {
+			t.Errorf("Authorization = %q, want basic auth for DI client", r.Header.Get("Authorization"))
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.Form.Get("grant_type") != "refresh_token" {
+			t.Errorf("grant_type = %q, want refresh_token", r.Form.Get("grant_type"))
+		}
+		if r.Form.Get("client_id") != "test-di-client" {
+			t.Errorf("client_id = %q, want test-di-client", r.Form.Get("client_id"))
+		}
+		if r.Form.Get("refresh_token") != "old-refresh" {
+			t.Errorf("refresh_token = %q, want old-refresh", r.Form.Get("refresh_token"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token_type":               "Bearer",
+			"access_token":             "new-access",
+			"refresh_token":            "new-refresh",
+			"expires_in":               3600,
+			"refresh_token_expires_in": 7776000,
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	origURL := diTokenURL
+	diTokenURL = srv.URL + "/di-oauth2-service/oauth/token"
+	t.Cleanup(func() { diTokenURL = origURL })
+
+	tokens := &Tokens{
+		OAuth2AccessToken:  "old-access",
+		OAuth2RefreshToken: "old-refresh",
+		DIClientID:         "test-di-client",
+		Domain:             DomainGlobal,
+		Email:              "test@example.com",
+		DisplayName:        "Test User",
+	}
+
+	refreshed, err := RefreshOAuth2(context.Background(), tokens, LoginOptions{})
+	if err != nil {
+		t.Fatalf("RefreshOAuth2() error: %v", err)
+	}
+
+	if refreshed.OAuth2AccessToken != "new-access" {
+		t.Errorf("OAuth2AccessToken = %q, want new-access", refreshed.OAuth2AccessToken)
+	}
+	if refreshed.OAuth2RefreshToken != "new-refresh" {
+		t.Errorf("OAuth2RefreshToken = %q, want new-refresh", refreshed.OAuth2RefreshToken)
+	}
+	if refreshed.DIClientID != "test-di-client" {
+		t.Errorf("DIClientID = %q, want test-di-client", refreshed.DIClientID)
+	}
+	if refreshed.Email != tokens.Email || refreshed.Domain != tokens.Domain || refreshed.DisplayName != tokens.DisplayName {
+		t.Error("metadata was not preserved")
+	}
+	if !refreshed.OAuth2ExpiresAt.After(time.Now()) {
+		t.Error("OAuth2ExpiresAt should be in the future")
+	}
+}
+
+func TestRefreshOAuth2_DIRefreshPreservesRefreshTokenWhenOmitted(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /di-oauth2-service/oauth/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token_type":   "Bearer",
+			"access_token": "new-access",
+			"expires_in":   3600,
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	origURL := diTokenURL
+	diTokenURL = srv.URL + "/di-oauth2-service/oauth/token"
+	t.Cleanup(func() { diTokenURL = origURL })
+
+	tokens := &Tokens{
+		OAuth2RefreshToken: "old-refresh",
+		DIClientID:         "test-di-client",
+	}
+
+	refreshed, err := RefreshOAuth2(context.Background(), tokens, LoginOptions{})
+	if err != nil {
+		t.Fatalf("RefreshOAuth2() error: %v", err)
+	}
+
+	if refreshed.OAuth2RefreshToken != "old-refresh" {
+		t.Errorf("OAuth2RefreshToken = %q, want old-refresh", refreshed.OAuth2RefreshToken)
+	}
+}

--- a/internal/garminauth/mfa_test.go
+++ b/internal/garminauth/mfa_test.go
@@ -294,6 +294,33 @@ func ssoMuxWithMFA(t *testing.T, expectedMFACode string) *http.ServeMux {
 		})
 	})
 
+	mux.HandleFunc("POST /di-oauth2-service/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			http.Error(w, "missing basic auth", http.StatusUnauthorized)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.Form.Get("grant_type") != diGrantType {
+			http.Error(w, "bad grant", http.StatusBadRequest)
+			return
+		}
+		if r.Form.Get("service_ticket") != "ST-mfa-ticket-999" {
+			http.Error(w, "bad ticket", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token_type":               "Bearer",
+			"access_token":             "mock-mfa-access-token",
+			"refresh_token":            "mock-mfa-refresh-token",
+			"expires_in":               3600,
+			"refresh_token_expires_in": 7776000,
+		})
+	})
+
 	return mux
 }
 
@@ -510,10 +537,7 @@ func TestSubmitMFA(t *testing.T) {
 func TestLoginHeadless_MFAWithCode(t *testing.T) {
 	mux := ssoMuxWithMFA(t, "123456")
 	srv, ep := mockSSO(t, mux)
-
-	origURL := oauthConsumerURL
-	oauthConsumerURL = srv.URL + "/oauth_consumer.json"
-	t.Cleanup(func() { oauthConsumerURL = origURL })
+	useMockDI(t, srv)
 
 	tokens, err := loginHeadless(context.Background(), "test@example.com", "correctpass",
 		LoginOptions{MFACode: "123456"}, ep)
@@ -527,9 +551,6 @@ func TestLoginHeadless_MFAWithCode(t *testing.T) {
 	if tokens.OAuth2AccessToken != "mock-mfa-access-token" {
 		t.Errorf("access_token = %q, want %q", tokens.OAuth2AccessToken, "mock-mfa-access-token")
 	}
-	if tokens.MFAToken != "mock-mfa-token" {
-		t.Errorf("mfa_token = %q, want %q", tokens.MFAToken, "mock-mfa-token")
-	}
 	if tokens.IsExpired() {
 		t.Error("token should not be expired")
 	}
@@ -538,10 +559,7 @@ func TestLoginHeadless_MFAWithCode(t *testing.T) {
 func TestLoginHeadless_MFAWithPrompt(t *testing.T) {
 	mux := ssoMuxWithMFA(t, "654321")
 	srv, ep := mockSSO(t, mux)
-
-	origURL := oauthConsumerURL
-	oauthConsumerURL = srv.URL + "/oauth_consumer.json"
-	t.Cleanup(func() { oauthConsumerURL = origURL })
+	useMockDI(t, srv)
 
 	promptCalled := false
 	tokens, err := loginHeadless(context.Background(), "test@example.com", "correctpass",
@@ -580,10 +598,7 @@ func TestLoginHeadless_MFANoCodeOrPrompt(t *testing.T) {
 func TestLoginHeadless_MFAWrongCode(t *testing.T) {
 	mux := ssoMuxWithMFA(t, "123456")
 	srv, ep := mockSSO(t, mux)
-
-	origURL := oauthConsumerURL
-	oauthConsumerURL = srv.URL + "/oauth_consumer.json"
-	t.Cleanup(func() { oauthConsumerURL = origURL })
+	useMockDI(t, srv)
 
 	_, err := loginHeadless(context.Background(), "test@example.com", "correctpass",
 		LoginOptions{MFACode: "wrong-code"}, ep)

--- a/internal/garminauth/refresh.go
+++ b/internal/garminauth/refresh.go
@@ -6,38 +6,47 @@ import (
 	"net/http"
 )
 
-// RefreshOAuth2 exchanges existing OAuth1 credentials for new OAuth2 tokens.
-// The provided tokens must have valid OAuth1 credentials (HasOAuth1() == true).
+// RefreshOAuth2 refreshes stored Garmin API credentials.
+// DI OAuth refresh tokens are preferred; legacy OAuth1 refresh remains for
+// older exported credentials.
 func RefreshOAuth2(ctx context.Context, tokens *Tokens, opts LoginOptions) (*Tokens, error) {
-	if !tokens.HasOAuth1() {
-		return nil, fmt.Errorf("no OAuth1 credentials available for refresh")
-	}
-
 	client := opts.HTTPClient
 	if client == nil {
 		client = &http.Client{}
 	}
 
-	ep := NewEndpoints(opts.domain())
-
-	consumer, err := fetchOAuthConsumer(ctx, client)
-	if err != nil {
-		return nil, fmt.Errorf("fetch oauth consumer: %w", err)
+	if tokens.DIClientID != "" && tokens.OAuth2RefreshToken != "" {
+		return refreshDI(ctx, client, tokens)
 	}
 
-	newTokens, err := exchangeOAuth2(ctx, client, ep, consumer,
-		tokens.OAuth1Token, tokens.OAuth1Secret, tokens.MFAToken)
-	if err != nil {
-		return nil, fmt.Errorf("oauth2 exchange: %w", err)
+	if tokens.HasOAuth1() {
+		ep := NewEndpoints(opts.domain())
+
+		consumer, err := fetchOAuthConsumer(ctx, client)
+		if err != nil {
+			return nil, fmt.Errorf("fetch oauth consumer: %w", err)
+		}
+
+		newTokens, err := exchangeOAuth2(ctx, client, ep, consumer,
+			tokens.OAuth1Token, tokens.OAuth1Secret, tokens.MFAToken)
+		if err != nil {
+			return nil, fmt.Errorf("oauth2 exchange: %w", err)
+		}
+
+		// Preserve existing metadata.
+		newTokens.Domain = tokens.Domain
+		newTokens.Email = tokens.Email
+		newTokens.OAuth1Token = tokens.OAuth1Token
+		newTokens.OAuth1Secret = tokens.OAuth1Secret
+		newTokens.MFAToken = tokens.MFAToken
+		newTokens.DisplayName = tokens.DisplayName
+
+		return newTokens, nil
 	}
 
-	// Preserve existing metadata.
-	newTokens.Domain = tokens.Domain
-	newTokens.Email = tokens.Email
-	newTokens.OAuth1Token = tokens.OAuth1Token
-	newTokens.OAuth1Secret = tokens.OAuth1Secret
-	newTokens.MFAToken = tokens.MFAToken
-	newTokens.DisplayName = tokens.DisplayName
+	if tokens.OAuth2RefreshToken != "" {
+		return refreshDI(ctx, client, tokens)
+	}
 
-	return newTokens, nil
+	return nil, fmt.Errorf("no refresh credentials available")
 }

--- a/internal/garminauth/sso.go
+++ b/internal/garminauth/sso.go
@@ -69,31 +69,14 @@ func loginBrowser(ctx context.Context, email string, opts LoginOptions, ep Endpo
 		return nil, fmt.Errorf("browser login timed out: %w", ctx.Err())
 	}
 
-	// Exchange ticket for tokens (reuse exchange logic from headless flow).
-	consumer, err := fetchOAuthConsumer(ctx, client)
+	// Exchange the callback service ticket for DI OAuth Bearer tokens.
+	tokens, err := exchangeServiceTicket(ctx, client, ticket, callbackURL)
 	if err != nil {
-		return nil, fmt.Errorf("fetch oauth consumer: %w", err)
-	}
-
-	oauth1Token, oauth1Secret, mfaToken, err := exchangePreauthorized(
-		ctx, client, ep, consumer, ticket, callbackURL)
-	if err != nil {
-		return nil, fmt.Errorf("oauth1 exchange: %w", err)
-	}
-
-	tokens, err := exchangeOAuth2(
-		ctx, client, ep, consumer, oauth1Token, oauth1Secret, mfaToken)
-	if err != nil {
-		return nil, fmt.Errorf("oauth2 exchange: %w", err)
+		return nil, fmt.Errorf("DI OAuth exchange: %w", err)
 	}
 
 	tokens.Domain = ep.domain()
 	tokens.Email = email
-	tokens.OAuth1Token = oauth1Token
-	tokens.OAuth1Secret = oauth1Secret
-	if mfaToken != "" {
-		tokens.MFAToken = mfaToken
-	}
 
 	return tokens, nil
 }

--- a/internal/garminauth/sso_headless.go
+++ b/internal/garminauth/sso_headless.go
@@ -44,7 +44,7 @@ type oauth2Response struct {
 var oauthConsumerURL = OAuthConsumerURL
 
 // LoginHeadless performs a headless SSO login using email and password.
-// It follows the Garmin SSO flow: embed -> signin -> credentials -> ticket -> OAuth1 -> OAuth2.
+// It follows the Garmin SSO flow: embed -> signin -> credentials -> ticket -> DI OAuth.
 func LoginHeadless(ctx context.Context, email, password string, opts LoginOptions) (*Tokens, error) {
 	ep := NewEndpoints(opts.domain())
 	return loginHeadless(ctx, email, password, opts, ep)
@@ -158,33 +158,14 @@ func loginHeadless(ctx context.Context, email, password string, opts LoginOption
 		}
 	}
 
-	// Step 4: Fetch OAuth consumer credentials.
-	consumer, err := fetchOAuthConsumer(ctx, client)
+	// Step 4: Exchange the service ticket for DI OAuth Bearer tokens.
+	tokens, err := exchangeServiceTicket(ctx, client, ticket, ep.SSOEmbed)
 	if err != nil {
-		return nil, fmt.Errorf("fetch oauth consumer: %w", err)
-	}
-
-	// Step 5: Exchange ticket for OAuth1 token.
-	oauth1Token, oauth1Secret, mfaToken, err := exchangePreauthorized(
-		ctx, client, ep, consumer, ticket, ep.SSOEmbed)
-	if err != nil {
-		return nil, fmt.Errorf("oauth1 exchange: %w", err)
-	}
-
-	// Step 6: Exchange OAuth1 for OAuth2 tokens.
-	tokens, err := exchangeOAuth2(
-		ctx, client, ep, consumer, oauth1Token, oauth1Secret, mfaToken)
-	if err != nil {
-		return nil, fmt.Errorf("oauth2 exchange: %w", err)
+		return nil, fmt.Errorf("DI OAuth exchange: %w", err)
 	}
 
 	tokens.Domain = ep.domain()
 	tokens.Email = email
-	tokens.OAuth1Token = oauth1Token
-	tokens.OAuth1Secret = oauth1Secret
-	if mfaToken != "" {
-		tokens.MFAToken = mfaToken
-	}
 
 	return tokens, nil
 }

--- a/internal/garminauth/sso_headless_test.go
+++ b/internal/garminauth/sso_headless_test.go
@@ -28,6 +28,13 @@ func mockSSO(t *testing.T, handler http.Handler) (*httptest.Server, Endpoints) {
 	}
 }
 
+func useMockDI(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	origURL := diTokenURL
+	diTokenURL = srv.URL + "/di-oauth2-service/oauth/token"
+	t.Cleanup(func() { diTokenURL = origURL })
+}
+
 // ssoMux returns an http.ServeMux that simulates the full Garmin SSO flow.
 func ssoMux(t *testing.T) *http.ServeMux {
 	t.Helper()
@@ -113,16 +120,40 @@ func ssoMux(t *testing.T) *http.ServeMux {
 		})
 	})
 
+	mux.HandleFunc("POST /di-oauth2-service/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			http.Error(w, "missing basic auth", http.StatusUnauthorized)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.Form.Get("grant_type") != diGrantType {
+			http.Error(w, "bad grant", http.StatusBadRequest)
+			return
+		}
+		if r.Form.Get("service_ticket") != "ST-mock-ticket-456" {
+			http.Error(w, "bad ticket", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token_type":               "Bearer",
+			"access_token":             "mock-access-token",
+			"refresh_token":            "mock-refresh-token",
+			"expires_in":               3600,
+			"refresh_token_expires_in": 7776000,
+		})
+	})
+
 	return mux
 }
 
 func TestLoginHeadless_Success(t *testing.T) {
 	mux := ssoMux(t)
 	srv, ep := mockSSO(t, mux)
-
-	origURL := oauthConsumerURL
-	oauthConsumerURL = srv.URL + "/oauth_consumer.json"
-	t.Cleanup(func() { oauthConsumerURL = origURL })
+	useMockDI(t, srv)
 
 	tokens, err := loginHeadless(context.Background(), "test@example.com", "correctpass", LoginOptions{}, ep)
 	if err != nil {
@@ -135,11 +166,8 @@ func TestLoginHeadless_Success(t *testing.T) {
 	if tokens.Domain != DomainGlobal {
 		t.Errorf("domain = %q, want %q", tokens.Domain, DomainGlobal)
 	}
-	if tokens.OAuth1Token != "mock-oauth1-token" {
-		t.Errorf("oauth1_token = %q, want %q", tokens.OAuth1Token, "mock-oauth1-token")
-	}
-	if tokens.OAuth1Secret != "mock-oauth1-secret" {
-		t.Errorf("oauth1_secret = %q, want %q", tokens.OAuth1Secret, "mock-oauth1-secret")
+	if tokens.OAuth1Token != "" || tokens.OAuth1Secret != "" {
+		t.Errorf("OAuth1 credentials should not be set for DI auth")
 	}
 	if tokens.OAuth2AccessToken != "mock-access-token" {
 		t.Errorf("access_token = %q, want %q", tokens.OAuth2AccessToken, "mock-access-token")
@@ -158,10 +186,7 @@ func TestLoginHeadless_Success(t *testing.T) {
 func TestLoginHeadless_BadCredentials(t *testing.T) {
 	mux := ssoMux(t)
 	srv, ep := mockSSO(t, mux)
-
-	origURL := oauthConsumerURL
-	oauthConsumerURL = srv.URL + "/oauth_consumer.json"
-	t.Cleanup(func() { oauthConsumerURL = origURL })
+	useMockDI(t, srv)
 
 	_, err := loginHeadless(context.Background(), "test@example.com", "wrongpass", LoginOptions{}, ep)
 	if err == nil {
@@ -222,10 +247,7 @@ func TestLoginHeadless_AccountLocked(t *testing.T) {
 func TestLoginHeadless_CustomHTTPClient(t *testing.T) {
 	mux := ssoMux(t)
 	srv, ep := mockSSO(t, mux)
-
-	origURL := oauthConsumerURL
-	oauthConsumerURL = srv.URL + "/oauth_consumer.json"
-	t.Cleanup(func() { oauthConsumerURL = origURL })
+	useMockDI(t, srv)
 
 	jar, err := cookiejar.New(nil)
 	if err != nil {

--- a/internal/garminauth/sso_test.go
+++ b/internal/garminauth/sso_test.go
@@ -13,10 +13,7 @@ import (
 func TestLoginBrowser_Success(t *testing.T) {
 	mux := ssoMux(t)
 	srv, ep := mockSSO(t, mux)
-
-	origURL := oauthConsumerURL
-	oauthConsumerURL = srv.URL + "/oauth_consumer.json"
-	t.Cleanup(func() { oauthConsumerURL = origURL })
+	useMockDI(t, srv)
 
 	origOpen := openBrowserFn
 	openBrowserFn = func(ssoURL string) error {
@@ -52,11 +49,8 @@ func TestLoginBrowser_Success(t *testing.T) {
 	if tokens.Domain != DomainGlobal {
 		t.Errorf("domain = %q, want %q", tokens.Domain, DomainGlobal)
 	}
-	if tokens.OAuth1Token != "mock-oauth1-token" {
-		t.Errorf("oauth1_token = %q, want %q", tokens.OAuth1Token, "mock-oauth1-token")
-	}
-	if tokens.OAuth1Secret != "mock-oauth1-secret" {
-		t.Errorf("oauth1_secret = %q, want %q", tokens.OAuth1Secret, "mock-oauth1-secret")
+	if tokens.OAuth1Token != "" || tokens.OAuth1Secret != "" {
+		t.Errorf("OAuth1 credentials should not be set for DI auth")
 	}
 	if tokens.OAuth2AccessToken != "mock-access-token" {
 		t.Errorf("access_token = %q, want %q", tokens.OAuth2AccessToken, "mock-access-token")

--- a/internal/garminauth/tokens.go
+++ b/internal/garminauth/tokens.go
@@ -17,6 +17,9 @@ type Tokens struct {
 	OAuth2RefreshToken string    `json:"oauth2_refresh_token"`
 	OAuth2ExpiresAt    time.Time `json:"oauth2_expires_at"`
 
+	// DIClientID is the Garmin DI OAuth client id used for refresh_token grants.
+	DIClientID string `json:"di_client_id,omitempty"`
+
 	// MFA token returned during MFA-enabled login.
 	MFAToken string `json:"mfa_token,omitempty"`
 
@@ -43,6 +46,12 @@ func (t *Tokens) IsExpired() bool {
 // that can be used to refresh the OAuth2 token.
 func (t *Tokens) HasOAuth1() bool {
 	return t.OAuth1Token != "" && t.OAuth1Secret != ""
+}
+
+// CanRefresh reports whether the tokens contain credentials that can refresh
+// the OAuth2 access token.
+func (t *Tokens) CanRefresh() bool {
+	return t.OAuth2RefreshToken != "" || t.HasOAuth1()
 }
 
 // Marshal serializes the tokens to JSON for keyring storage.

--- a/internal/garminauth/tokens_test.go
+++ b/internal/garminauth/tokens_test.go
@@ -86,6 +86,7 @@ func TestTokens_MarshalRoundtrip(t *testing.T) {
 		OAuth2AccessToken:  "access-tok",
 		OAuth2RefreshToken: "refresh-tok",
 		OAuth2ExpiresAt:    expiry,
+		DIClientID:         "di-client-id",
 		MFAToken:           "mfa-tok",
 		Domain:             DomainGlobal,
 		DisplayName:        "Test User",
@@ -114,6 +115,9 @@ func TestTokens_MarshalRoundtrip(t *testing.T) {
 	if restored.OAuth2RefreshToken != original.OAuth2RefreshToken {
 		t.Errorf("OAuth2RefreshToken = %q, want %q", restored.OAuth2RefreshToken, original.OAuth2RefreshToken)
 	}
+	if restored.DIClientID != original.DIClientID {
+		t.Errorf("DIClientID = %q, want %q", restored.DIClientID, original.DIClientID)
+	}
 	if !restored.OAuth2ExpiresAt.Equal(original.OAuth2ExpiresAt) {
 		t.Errorf("OAuth2ExpiresAt = %v, want %v", restored.OAuth2ExpiresAt, original.OAuth2ExpiresAt)
 	}
@@ -128,6 +132,41 @@ func TestTokens_MarshalRoundtrip(t *testing.T) {
 	}
 	if restored.Email != original.Email {
 		t.Errorf("Email = %q, want %q", restored.Email, original.Email)
+	}
+}
+
+func TestTokens_CanRefresh(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		tokens Tokens
+		want   bool
+	}{
+		{
+			name:   "DI refresh token",
+			tokens: Tokens{OAuth2RefreshToken: "refresh"},
+			want:   true,
+		},
+		{
+			name:   "legacy OAuth1 credentials",
+			tokens: Tokens{OAuth1Token: "token", OAuth1Secret: "secret"},
+			want:   true,
+		},
+		{
+			name: "none",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.tokens.CanRefresh(); got != tt.want {
+				t.Errorf("CanRefresh() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/testutil/tokens.go
+++ b/internal/testutil/tokens.go
@@ -15,6 +15,7 @@ func TestTokens() *garminauth.Tokens {
 		OAuth2AccessToken:  "test-access-token",
 		OAuth2RefreshToken: "test-refresh-token",
 		OAuth2ExpiresAt:    time.Now().Add(time.Hour),
+		DIClientID:         "test-di-client-id",
 		Domain:             garminauth.DomainGlobal,
 		Email:              "test@example.com",
 		DisplayName:        "Test User",


### PR DESCRIPTION
## Summary

- replace fresh SSO ticket exchange with Garmin DI OAuth service-ticket exchange
- store the DI client id so refresh_token grants can renew DI credentials
- preserve legacy OAuth1 refresh for existing exported credentials without DI metadata
- update auth/e2e tests and docs to reflect DI OAuth tokens

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Chore (CI, dependencies, tooling)

## Verification

- [x] `make fmt`
- [x] `make lint`
- [x] `make test`
- [x] `make ci`
- [x] `make test-e2e` (compiled; skipped live tests without GARMIN_EMAIL/GARMIN_PASSWORD)
- [x] local smoke: `go run ./cmd/gccli --json profile` with stored credentials succeeded

## Checklist

- [x] `make fmt` — code is formatted
- [x] `make lint` — no linting errors
- [x] `make test` — all tests pass
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title is descriptive and follows conventional format