### PR TITLE
feat: add gccli activities types command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fast, script-friendly CLI for Garmin Connect. Access activities, health data, bo
 
 ## Features
 
-- **Activities** — list, search, view details, download (FIT/GPX/TCX/KML/CSV), upload, create manual entries (with date), rename, retype, delete, set exercise sets for strength training
+- **Activities** — list, search, view details, download (FIT/GPX/TCX/KML/CSV), upload, create manual entries (with date), rename, retype, delete, set exercise sets for strength training, list activity types
 - **Exercise Catalog** — browse Garmin's exercise categories and exercises for strength training
 - **Health Data** — daily summaries, steps, heart rate, resting HR, sleep, stress, HRV, SpO2, respiration, body battery, floors, training readiness/status, VO2max, fitness age, race predictions, endurance/hill scores, intensity minutes, lactate threshold, cycling FTP
 - **Body Composition** — weight tracking, body fat, muscle mass, blood pressure, FIT file encoding for composition uploads
@@ -283,6 +283,9 @@ gccli activity rename <id> "New Name"
 gccli activity retype <id> --type-id 1 --type-key running
 gccli activity delete <id>
 gccli activity delete <id> --force
+
+# Activity types
+gccli activities types                   # List all Garmin activity types
 ```
 
 ### Health Data

--- a/docs/index.html
+++ b/docs/index.html
@@ -538,6 +538,7 @@ gccli activities list --limit 5</pre>
               <div class="cmd-row"><div class="cmd">gccli exercises list -c BENCH_PRESS</div><div class="desc">List exercises in a category</div></div>
               <div class="cmd-row"><div class="cmd">gccli activity rename &lt;id&gt; "New Name"</div><div class="desc">Rename an activity</div></div>
               <div class="cmd-row"><div class="cmd">gccli activity delete &lt;id&gt; --force</div><div class="desc">Delete an activity</div></div>
+              <div class="cmd-row"><div class="cmd">gccli activities types</div><div class="desc">List all Garmin activity types</div></div>
             </div>
           </div>
 

--- a/internal/cmd/activities.go
+++ b/internal/cmd/activities.go
@@ -14,6 +14,7 @@ type ActivitiesCmd struct {
 	List   ActivitiesListCmd   `cmd:"" default:"withargs" help:"List recent activities."`
 	Count  ActivitiesCountCmd  `cmd:"" help:"Show total activity count."`
 	Search ActivitiesSearchCmd `cmd:"" help:"Search activities by date range."`
+	Types  ActivitiesTypesCmd  `cmd:"" help:"List all activity types supported by Garmin."`
 }
 
 // ActivitiesListCmd lists recent activities.
@@ -223,4 +224,71 @@ func formatCalories(cal float64) string {
 		return "-"
 	}
 	return fmt.Sprintf("%d", int(cal))
+}
+
+// ActivitiesTypesCmd lists all activity types supported by Garmin.
+type ActivitiesTypesCmd struct{}
+
+func (c *ActivitiesTypesCmd) Run(g *Globals) error {
+	client, err := resolveClient(g)
+	if err != nil {
+		return err
+	}
+
+	data, err := client.GetActivityTypes(g.Context)
+	if err != nil {
+		return fmt.Errorf("get activity types: %w", err)
+	}
+
+	if outfmt.IsJSON(g.Context) {
+		return outfmt.WriteJSON(os.Stdout, json.RawMessage(data))
+	}
+
+	var types []map[string]any
+	if err := json.Unmarshal(data, &types); err != nil {
+		return fmt.Errorf("parse activity types: %w", err)
+	}
+
+	header := []string{"ID", "TYPE KEY", "PARENT ID", "TRIMMABLE"}
+	rows := make([][]string, 0, len(types))
+	for _, t := range types {
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", int(jsonFloat(t, "typeId"))),
+			jsonString(t, "typeKey"),
+			formatParentID(t),
+			formatTrimmable(t),
+		})
+	}
+
+	if outfmt.IsPlain(g.Context) {
+		return outfmt.WritePlain(os.Stdout, rows)
+	}
+	return outfmt.WriteTable(os.Stdout, header, rows)
+}
+
+// formatParentID formats parentTypeId (handles null as "-").
+func formatParentID(t map[string]any) string {
+	v, ok := t["parentTypeId"]
+	if !ok || v == nil {
+		return "-"
+	}
+	if f, ok := v.(float64); ok {
+		return fmt.Sprintf("%d", int(f))
+	}
+	return "-"
+}
+
+// formatTrimmable formats trimmable as "yes"/"no".
+func formatTrimmable(t map[string]any) string {
+	v, ok := t["trimmable"]
+	if !ok || v == nil {
+		return "-"
+	}
+	if b, ok := v.(bool); ok {
+		if b {
+			return "yes"
+		}
+		return "no"
+	}
+	return "-"
 }

--- a/internal/cmd/activities_test.go
+++ b/internal/cmd/activities_test.go
@@ -51,6 +51,15 @@ func activitiesTestServer(t *testing.T) *httptest.Server {
 		_, _ = w.Write([]byte(`{"totalCount":42}`))
 	})
 
+	mux.HandleFunc("/activity-service/activity/activityTypes", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"typeId":1,"typeKey":"running","parentTypeId":17,"isHidden":false,"restricted":false,"trimmable":true},
+			{"typeId":2,"typeKey":"cycling","parentTypeId":17,"isHidden":false,"restricted":false,"trimmable":true},
+			{"typeId":181,"typeKey":"ultra_run","parentTypeId":1,"isHidden":false,"restricted":false,"trimmable":true}
+		]`))
+	})
+
 	return httptest.NewServer(mux)
 }
 
@@ -576,5 +585,64 @@ func TestJsonFloat(t *testing.T) {
 				t.Errorf("jsonFloat() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// --- ActivitiesTypesCmd tests ---
+
+func TestExecute_ActivitiesTypesHelp(t *testing.T) {
+	code := Execute([]string{"activities", "types", "--help"}, "1.0.0", "abc123", "2024-01-01")
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}
+
+func TestActivitiesTypes_Table(t *testing.T) {
+	server := activitiesTestServer(t)
+	defer server.Close()
+
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	overrideNewClient(t, server)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "test@example.com")
+	cmd := &ActivitiesTypesCmd{}
+	err := cmd.Run(g)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestActivitiesTypes_JSON(t *testing.T) {
+	server := activitiesTestServer(t)
+	defer server.Close()
+
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	overrideNewClient(t, server)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.JSON, "test@example.com")
+	cmd := &ActivitiesTypesCmd{}
+	err := cmd.Run(g)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	// JSON output goes to stdout; just verify no error.
+}
+
+func TestActivitiesTypes_NoAccount(t *testing.T) {
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "")
+	cmd := &ActivitiesTypesCmd{}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no account specified") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/garminapi/activities.go
+++ b/internal/garminapi/activities.go
@@ -315,3 +315,8 @@ func (c *Client) DeleteActivity(ctx context.Context, activityID string) error {
 	_, err := c.ConnectAPI(ctx, http.MethodDelete, "/activity-service/activity/"+activityID, nil)
 	return err
 }
+
+// GetActivityTypes returns all activity types from Garmin Connect.
+func (c *Client) GetActivityTypes(ctx context.Context) (json.RawMessage, error) {
+	return c.ConnectAPI(ctx, http.MethodGet, "/activity-service/activity/activityTypes", nil)
+}

--- a/internal/garminapi/activities_test.go
+++ b/internal/garminapi/activities_test.go
@@ -851,3 +851,55 @@ func TestDeleteActivity_ServerError(t *testing.T) {
 		t.Errorf("StatusCode = %d, want 404", apiErr.StatusCode)
 	}
 }
+
+// --- GetActivityTypes tests ---
+
+func TestGetActivityTypes_Success(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/activity-service/activity/activityTypes" {
+			t.Errorf("path = %s, want /activity-service/activity/activityTypes", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		_, _ = w.Write([]byte(`[
+			{"typeId":1,"typeKey":"running","parentTypeId":17,"isHidden":false,"restricted":false,"trimmable":true},
+			{"typeId":2,"typeKey":"cycling","parentTypeId":17,"isHidden":false,"restricted":false,"trimmable":true}
+		]`))
+	})
+
+	_, client := testServer(t, handler)
+	data, err := client.GetActivityTypes(context.Background())
+	if err != nil {
+		t.Fatalf("GetActivityTypes: %v", err)
+	}
+
+	var types []map[string]any
+	if err := json.Unmarshal(data, &types); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(types) != 2 {
+		t.Errorf("len = %d, want 2", len(types))
+	}
+	if types[0]["typeKey"] != "running" {
+		t.Errorf("typeKey = %v, want running", types[0]["typeKey"])
+	}
+}
+
+func TestGetActivityTypes_ServerError(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("error"))
+	})
+
+	_, client := testServer(t, handler)
+	_, err := client.GetActivityTypes(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var apiErr *GarminAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected GarminAPIError, got %T: %v", err, err)
+	}
+}

--- a/skills/gccli/SKILL.md
+++ b/skills/gccli/SKILL.md
@@ -54,6 +54,7 @@ Common commands
 - Rename activity: `gccli activity rename <id> "New Name"`
 - Retype activity: `gccli activity retype <id> running`
 - Delete activity: `gccli activity delete <id> --force`
+- Activity types: `gccli activities types`
 - Health summary: `gccli health summary [date]`
 - Steps chart: `gccli health steps [date]`
 - Daily steps range: `gccli health steps daily --start 2024-01-01 --end 2024-01-31`


### PR DESCRIPTION
Expose the Garmin Connect /gc-api/activity-service/activity/activityTypes endpoint via a new `gccli activities types` command.

## Summary

<!-- Brief description of the changes in this PR. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Chore (CI, dependencies, tooling)

## Checklist

- [x] `make fmt` — code is formatted
- [x] `make lint` — no linting errors
- [x] `make test` — all tests pass
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title is descriptive and follows conventional format
