### PR TITLE
refactor(auth): tighten DI OAuth client_id handling and validation

### DIFF
--- a/internal/garminauth/di.go
+++ b/internal/garminauth/di.go
@@ -39,44 +39,47 @@ type diTokenResponse struct {
 
 // exchangeServiceTicket exchanges a Garmin CAS service ticket for DI OAuth
 // Bearer tokens. serviceURL must match the service URL used to issue ticket.
+//
+// Service tickets are single-use, so we don't iterate over fallback client_ids
+// — a failed attempt would burn the ticket. The newest client_id is used; if
+// Garmin rotates the constant, the diClientIDs list must be updated.
 func exchangeServiceTicket(ctx context.Context, client *http.Client, ticket, serviceURL string) (*Tokens, error) {
-	var failures []string
-
-	for _, clientID := range diClientIDs {
-		values := url.Values{
-			"client_id":      {clientID},
-			"service_ticket": {ticket},
-			"grant_type":     {diGrantType},
-			"service_url":    {serviceURL},
-		}
-
-		resp, err := postDIForm(ctx, client, clientID, values)
-		if err != nil {
-			failures = append(failures, fmt.Sprintf("%s: %v", clientID, err))
-			continue
-		}
-
-		tokens := tokensFromDIResponse(resp, clientID)
-		tokens.DIClientID = extractClientIDFromJWT(tokens.OAuth2AccessToken, clientID)
-		return tokens, nil
+	clientID := diClientIDs[0]
+	values := url.Values{
+		"client_id":      {clientID},
+		"service_ticket": {ticket},
+		"grant_type":     {diGrantType},
+		"service_url":    {serviceURL},
 	}
 
-	return nil, fmt.Errorf("DI token exchange failed for all client ids: %s", strings.Join(failures, "; "))
+	resp, err := postDIForm(ctx, client, clientID, values)
+	if err != nil {
+		return nil, fmt.Errorf("DI token exchange (%s): %w", clientID, err)
+	}
+
+	tokens := tokensFromDIResponse(resp, clientID)
+	tokens.DIClientID = extractClientIDFromJWT(tokens.OAuth2AccessToken, clientID)
+	return tokens, nil
 }
 
 // refreshDI refreshes DI OAuth Bearer tokens using a stored refresh token.
+// Refresh tokens are bound to the client_id that issued them, so when we know
+// the issuing client_id we only attempt that one; iterating fallbacks is
+// reserved for legacy imports where DIClientID is unset.
 func refreshDI(ctx context.Context, client *http.Client, tokens *Tokens) (*Tokens, error) {
 	if tokens.OAuth2RefreshToken == "" {
 		return nil, fmt.Errorf("no DI refresh token available")
 	}
 
-	clientIDs := diClientIDs
+	var clientIDs []string
 	if tokens.DIClientID != "" {
-		clientIDs = append([]string{tokens.DIClientID}, diClientIDs...)
+		clientIDs = []string{tokens.DIClientID}
+	} else {
+		clientIDs = diClientIDs
 	}
 
 	var failures []string
-	for _, clientID := range dedupeStrings(clientIDs) {
+	for _, clientID := range clientIDs {
 		values := url.Values{
 			"grant_type":    {"refresh_token"},
 			"client_id":     {clientID},
@@ -103,7 +106,7 @@ func refreshDI(ctx context.Context, client *http.Client, tokens *Tokens) (*Token
 		return refreshed, nil
 	}
 
-	return nil, fmt.Errorf("DI token refresh failed for all client ids: %s", strings.Join(failures, "; "))
+	return nil, fmt.Errorf("DI token refresh failed: %s", strings.Join(failures, "; "))
 }
 
 func postDIForm(ctx context.Context, client *http.Client, clientID string, values url.Values) (*diTokenResponse, error) {
@@ -140,6 +143,9 @@ func postDIForm(ctx context.Context, client *http.Client, clientID string, value
 	if parsed.AccessToken == "" {
 		return nil, fmt.Errorf("response missing access_token")
 	}
+	if parsed.ExpiresIn <= 0 {
+		return nil, fmt.Errorf("response has invalid expires_in: %d", parsed.ExpiresIn)
+	}
 	return &parsed, nil
 }
 
@@ -169,6 +175,9 @@ func basicAuth(clientID string) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(clientID+":"))
 }
 
+// extractClientIDFromJWT decodes the JWT payload to read the client_id claim.
+// The signature is NOT verified — the value is informational only and is used
+// solely as a hint for which client_id to send on subsequent refresh.
 func extractClientIDFromJWT(token, fallback string) string {
 	parts := strings.Split(token, ".")
 	if len(parts) < 2 {
@@ -187,17 +196,4 @@ func extractClientIDFromJWT(token, fallback string) string {
 		return fallback
 	}
 	return claims.ClientID
-}
-
-func dedupeStrings(values []string) []string {
-	seen := make(map[string]struct{}, len(values))
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		out = append(out, value)
-	}
-	return out
 }

--- a/internal/garminauth/di_test.go
+++ b/internal/garminauth/di_test.go
@@ -2,9 +2,12 @@ package garminauth
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -107,5 +110,260 @@ func TestRefreshOAuth2_DIRefreshPreservesRefreshTokenWhenOmitted(t *testing.T) {
 
 	if refreshed.OAuth2RefreshToken != "old-refresh" {
 		t.Errorf("OAuth2RefreshToken = %q, want old-refresh", refreshed.OAuth2RefreshToken)
+	}
+}
+
+// TestRefreshDI_OnlyTriesStoredClientID verifies that when DIClientID is set,
+// refresh attempts only that client_id and does not iterate fallbacks even
+// when the server rejects it. Refresh tokens are bound to the issuing
+// client_id, so iterating would burn requests for no possible benefit.
+func TestRefreshDI_OnlyTriesStoredClientID(t *testing.T) {
+	var calls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /di-oauth2-service/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if r.Header.Get("Authorization") != basicAuth("test-di-client") {
+			t.Errorf("Authorization = %q, want basic auth for test-di-client", r.Header.Get("Authorization"))
+		}
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	origURL := diTokenURL
+	diTokenURL = srv.URL + "/di-oauth2-service/oauth/token"
+	t.Cleanup(func() { diTokenURL = origURL })
+
+	tokens := &Tokens{
+		OAuth2RefreshToken: "old-refresh",
+		DIClientID:         "test-di-client",
+	}
+
+	_, err := RefreshOAuth2(context.Background(), tokens, LoginOptions{})
+	if err == nil {
+		t.Fatal("expected error from refresh")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("server received %d calls, want exactly 1", got)
+	}
+}
+
+// TestRefreshDI_IteratesWhenClientIDUnknown verifies that legacy imports
+// without a stored DIClientID iterate the hardcoded list.
+func TestRefreshDI_IteratesWhenClientIDUnknown(t *testing.T) {
+	var calls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /di-oauth2-service/oauth/token", func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	origURL := diTokenURL
+	diTokenURL = srv.URL + "/di-oauth2-service/oauth/token"
+	t.Cleanup(func() { diTokenURL = origURL })
+
+	tokens := &Tokens{OAuth2RefreshToken: "old-refresh"}
+
+	_, err := RefreshOAuth2(context.Background(), tokens, LoginOptions{})
+	if err == nil {
+		t.Fatal("expected error from refresh")
+	}
+	if got, want := calls.Load(), int32(len(diClientIDs)); got != want {
+		t.Errorf("server received %d calls, want %d (one per fallback client_id)", got, want)
+	}
+}
+
+// TestExchangeServiceTicket_Success verifies the happy path uses the first
+// (newest) client_id and populates token fields.
+func TestExchangeServiceTicket_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /di-oauth2-service/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != basicAuth(diClientIDs[0]) {
+			t.Errorf("Authorization for %q expected, got %q", diClientIDs[0], r.Header.Get("Authorization"))
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.Form.Get("client_id") != diClientIDs[0] {
+			t.Errorf("client_id = %q, want %q", r.Form.Get("client_id"), diClientIDs[0])
+		}
+		if r.Form.Get("grant_type") != diGrantType {
+			t.Errorf("grant_type = %q, want %q", r.Form.Get("grant_type"), diGrantType)
+		}
+		if r.Form.Get("service_ticket") != "ST-test-ticket" {
+			t.Errorf("service_ticket = %q, want ST-test-ticket", r.Form.Get("service_ticket"))
+		}
+		if r.Form.Get("service_url") != "https://example.com/cb" {
+			t.Errorf("service_url = %q, want https://example.com/cb", r.Form.Get("service_url"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token_type":    "Bearer",
+			"access_token":  "access-tok",
+			"refresh_token": "refresh-tok",
+			"expires_in":    3600,
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	origURL := diTokenURL
+	diTokenURL = srv.URL + "/di-oauth2-service/oauth/token"
+	t.Cleanup(func() { diTokenURL = origURL })
+
+	tokens, err := exchangeServiceTicket(context.Background(), srv.Client(), "ST-test-ticket", "https://example.com/cb")
+	if err != nil {
+		t.Fatalf("exchangeServiceTicket() error: %v", err)
+	}
+	if tokens.OAuth2AccessToken != "access-tok" {
+		t.Errorf("OAuth2AccessToken = %q, want access-tok", tokens.OAuth2AccessToken)
+	}
+	if tokens.OAuth2RefreshToken != "refresh-tok" {
+		t.Errorf("OAuth2RefreshToken = %q, want refresh-tok", tokens.OAuth2RefreshToken)
+	}
+	if tokens.DIClientID != diClientIDs[0] {
+		t.Errorf("DIClientID = %q, want %q", tokens.DIClientID, diClientIDs[0])
+	}
+}
+
+// TestExchangeServiceTicket_DoesNotIterate verifies a single failed attempt
+// does not retry against fallback client_ids — service tickets are single-use.
+func TestExchangeServiceTicket_DoesNotIterate(t *testing.T) {
+	var calls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /di-oauth2-service/oauth/token", func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		http.Error(w, "bad ticket", http.StatusBadRequest)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	origURL := diTokenURL
+	diTokenURL = srv.URL + "/di-oauth2-service/oauth/token"
+	t.Cleanup(func() { diTokenURL = origURL })
+
+	_, err := exchangeServiceTicket(context.Background(), srv.Client(), "ST-bad", "https://example.com/cb")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("server received %d calls, want exactly 1", got)
+	}
+}
+
+// TestPostDIForm_RejectsInvalidExpiresIn verifies that a non-positive
+// expires_in produces an error rather than a born-expired token.
+func TestPostDIForm_RejectsInvalidExpiresIn(t *testing.T) {
+	cases := []struct {
+		name      string
+		expiresIn int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("POST /di-oauth2-service/oauth/token", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"token_type":   "Bearer",
+					"access_token": "a",
+					"expires_in":   tc.expiresIn,
+				})
+			})
+			srv := httptest.NewServer(mux)
+			t.Cleanup(srv.Close)
+
+			origURL := diTokenURL
+			diTokenURL = srv.URL + "/di-oauth2-service/oauth/token"
+			t.Cleanup(func() { diTokenURL = origURL })
+
+			_, err := exchangeServiceTicket(context.Background(), srv.Client(), "ST-ok", "https://example.com/cb")
+			if err == nil {
+				t.Fatal("expected error for non-positive expires_in")
+			}
+			if !strings.Contains(err.Error(), "invalid expires_in") {
+				t.Errorf("error = %q, want to contain 'invalid expires_in'", err.Error())
+			}
+		})
+	}
+}
+
+func TestExtractClientIDFromJWT(t *testing.T) {
+	encode := func(payload string) string {
+		// Header.payload.sig — we only decode the middle segment.
+		body := base64.RawURLEncoding.EncodeToString([]byte(payload))
+		return "header." + body + ".sig"
+	}
+
+	cases := []struct {
+		name     string
+		token    string
+		fallback string
+		want     string
+	}{
+		{
+			name:     "valid client_id claim",
+			token:    encode(`{"client_id":"FROM_JWT","sub":"u"}`),
+			fallback: "FALLBACK",
+			want:     "FROM_JWT",
+		},
+		{
+			name:     "missing client_id claim",
+			token:    encode(`{"sub":"u"}`),
+			fallback: "FALLBACK",
+			want:     "FALLBACK",
+		},
+		{
+			name:     "empty client_id claim",
+			token:    encode(`{"client_id":""}`),
+			fallback: "FALLBACK",
+			want:     "FALLBACK",
+		},
+		{
+			name:     "malformed JSON payload",
+			token:    encode(`not json`),
+			fallback: "FALLBACK",
+			want:     "FALLBACK",
+		},
+		{
+			name:     "invalid base64 payload",
+			token:    "header.!!!.sig",
+			fallback: "FALLBACK",
+			want:     "FALLBACK",
+		},
+		{
+			name:     "fewer than 2 segments",
+			token:    "single",
+			fallback: "FALLBACK",
+			want:     "FALLBACK",
+		},
+		{
+			name:     "empty token",
+			token:    "",
+			fallback: "FALLBACK",
+			want:     "FALLBACK",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractClientIDFromJWT(tc.token, tc.fallback)
+			if got != tc.want {
+				t.Errorf("extractClientIDFromJWT() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/garminauth/refresh.go
+++ b/internal/garminauth/refresh.go
@@ -9,6 +9,10 @@ import (
 // RefreshOAuth2 refreshes stored Garmin API credentials.
 // DI OAuth refresh tokens are preferred; legacy OAuth1 refresh remains for
 // older exported credentials.
+//
+// When DI credentials are present the refresh is terminal — failures do not
+// fall through to the OAuth1 path, since the DI refresh_token has been
+// consumed or revoked and OAuth1 fallback would yield stale state.
 func RefreshOAuth2(ctx context.Context, tokens *Tokens, opts LoginOptions) (*Tokens, error) {
 	client := opts.HTTPClient
 	if client == nil {


### PR DESCRIPTION
## Summary

Follow-up to #45. Addresses review feedback around the DI OAuth flow:

- `exchangeServiceTicket` no longer iterates fallback `client_id`s. Service tickets are single-use, so retrying on failure would burn the ticket and surface a misleading "all client_ids failed" error. The newest `client_id` is used; if Garmin rotates the constant, the `diClientIDs` list must be updated.
- `refreshDI` only attempts the stored `DIClientID` when it is set. Refresh tokens are bound to their issuing `client_id`, so iterating fallbacks guarantees additional 401s with no chance of success. Iteration is preserved for legacy imports where `DIClientID` is unset.
- `postDIForm` rejects responses with non-positive `expires_in` to avoid born-expired tokens triggering refresh loops.
- Documented that the JWT in `extractClientIDFromJWT` is not signature-verified and is informational only.
- Documented that DI refresh failures are terminal and do not fall through to OAuth1.

## Test plan

- [x] `make fmt`
- [x] `make lint`
- [x] `make test`

New direct unit tests:

- `TestRefreshDI_OnlyTriesStoredClientID` — exactly one HTTP call when `DIClientID` is set.
- `TestRefreshDI_IteratesWhenClientIDUnknown` — iterates the hardcoded list for legacy imports.
- `TestExchangeServiceTicket_Success` — happy path uses the newest `client_id` and populates token fields.
- `TestExchangeServiceTicket_DoesNotIterate` — single attempt on failure.
- `TestPostDIForm_RejectsInvalidExpiresIn` — zero/negative `expires_in` produces an error.
- `TestExtractClientIDFromJWT` — table test covering valid, malformed, missing-claim, invalid-base64, segment-count, and empty-token cases.