### PR TITLE
refactor(activities): sort and enrich activity types output

### DIFF
--- a/internal/cmd/activities.go
+++ b/internal/cmd/activities.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/bpauli/gccli/internal/outfmt"
@@ -173,6 +174,18 @@ func jsonFloat(m map[string]any, key string) float64 {
 	return 0
 }
 
+// jsonBool extracts a bool from a JSON map. The second return value reports
+// whether the key was present and held a bool, distinguishing "false" from
+// "missing" or "null" (which both render as "-" in tables).
+func jsonBool(m map[string]any, key string) (bool, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return false, false
+	}
+	b, ok := v.(bool)
+	return b, ok
+}
+
 // activityTypeKey extracts the activity type key from nested activityType.typeKey.
 func activityTypeKey(a map[string]any) string {
 	at, ok := a["activityType"]
@@ -244,26 +257,51 @@ func (c *ActivitiesTypesCmd) Run(g *Globals) error {
 		return outfmt.WriteJSON(os.Stdout, json.RawMessage(data))
 	}
 
-	var types []map[string]any
-	if err := json.Unmarshal(data, &types); err != nil {
-		return fmt.Errorf("parse activity types: %w", err)
+	types, err := parseActivityTypes(data)
+	if err != nil {
+		return err
 	}
 
-	header := []string{"ID", "TYPE KEY", "PARENT ID", "TRIMMABLE"}
+	rows := formatActivityTypeRows(types)
+	header := activityTypesHeader()
+
+	if outfmt.IsPlain(g.Context) {
+		return outfmt.WritePlain(os.Stdout, rows)
+	}
+	return outfmt.WriteTable(os.Stdout, header, rows)
+}
+
+func activityTypesHeader() []string {
+	return []string{"ID", "TYPE KEY", "PARENT ID", "TRIMMABLE", "HIDDEN", "RESTRICTED"}
+}
+
+// parseActivityTypes unmarshals the activity types payload and sorts by typeId
+// so table/plain output is stable across runs.
+func parseActivityTypes(data json.RawMessage) ([]map[string]any, error) {
+	var types []map[string]any
+	if err := json.Unmarshal(data, &types); err != nil {
+		return nil, fmt.Errorf("parse activity types: %w", err)
+	}
+	sort.SliceStable(types, func(i, j int) bool {
+		return jsonFloat(types[i], "typeId") < jsonFloat(types[j], "typeId")
+	})
+	return types, nil
+}
+
+// formatActivityTypeRows extracts table rows from activity-type data.
+func formatActivityTypeRows(types []map[string]any) [][]string {
 	rows := make([][]string, 0, len(types))
 	for _, t := range types {
 		rows = append(rows, []string{
 			fmt.Sprintf("%d", int(jsonFloat(t, "typeId"))),
 			jsonString(t, "typeKey"),
 			formatParentID(t),
-			formatTrimmable(t),
+			formatYesNo(t, "trimmable"),
+			formatYesNo(t, "isHidden"),
+			formatYesNo(t, "restricted"),
 		})
 	}
-
-	if outfmt.IsPlain(g.Context) {
-		return outfmt.WritePlain(os.Stdout, rows)
-	}
-	return outfmt.WriteTable(os.Stdout, header, rows)
+	return rows
 }
 
 // formatParentID formats parentTypeId (handles null as "-").
@@ -278,17 +316,14 @@ func formatParentID(t map[string]any) string {
 	return "-"
 }
 
-// formatTrimmable formats trimmable as "yes"/"no".
-func formatTrimmable(t map[string]any) string {
-	v, ok := t["trimmable"]
-	if !ok || v == nil {
+// formatYesNo renders a bool field as "yes"/"no", or "-" when missing.
+func formatYesNo(m map[string]any, key string) string {
+	b, ok := jsonBool(m, key)
+	if !ok {
 		return "-"
 	}
-	if b, ok := v.(bool); ok {
-		if b {
-			return "yes"
-		}
-		return "no"
+	if b {
+		return "yes"
 	}
-	return "-"
+	return "no"
 }

--- a/internal/cmd/activities_test.go
+++ b/internal/cmd/activities_test.go
@@ -634,6 +634,96 @@ func TestActivitiesTypes_JSON(t *testing.T) {
 	// JSON output goes to stdout; just verify no error.
 }
 
+func TestParseActivityTypes_SortsByTypeID(t *testing.T) {
+	data := []byte(`[
+		{"typeId":181,"typeKey":"ultra_run"},
+		{"typeId":1,"typeKey":"running"},
+		{"typeId":17,"typeKey":"other"}
+	]`)
+	types, err := parseActivityTypes(data)
+	if err != nil {
+		t.Fatalf("parseActivityTypes: %v", err)
+	}
+	want := []string{"running", "other", "ultra_run"}
+	for i, w := range want {
+		if got := jsonString(types[i], "typeKey"); got != w {
+			t.Errorf("types[%d].typeKey = %q, want %q", i, got, w)
+		}
+	}
+}
+
+func TestParseActivityTypes_InvalidJSON(t *testing.T) {
+	_, err := parseActivityTypes([]byte("not-json"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestFormatActivityTypeRows(t *testing.T) {
+	types := []map[string]any{
+		{
+			"typeId":       float64(1),
+			"typeKey":      "running",
+			"parentTypeId": float64(17),
+			"trimmable":    true,
+			"isHidden":     false,
+			"restricted":   false,
+		},
+		{
+			// parentTypeId null, trimmable missing, hidden true.
+			"typeId":       float64(17),
+			"typeKey":      "other",
+			"parentTypeId": nil,
+			"isHidden":     true,
+			"restricted":   false,
+		},
+	}
+	rows := formatActivityTypeRows(types)
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2", len(rows))
+	}
+	want := [][]string{
+		{"1", "running", "17", "yes", "no", "no"},
+		{"17", "other", "-", "-", "yes", "no"},
+	}
+	for i, row := range rows {
+		if len(row) != len(want[i]) {
+			t.Fatalf("row[%d] has %d cols, want %d", i, len(row), len(want[i]))
+		}
+		for j, cell := range row {
+			if cell != want[i][j] {
+				t.Errorf("row[%d][%d] = %q, want %q", i, j, cell, want[i][j])
+			}
+		}
+	}
+}
+
+func TestJsonBool(t *testing.T) {
+	m := map[string]any{
+		"yes":     true,
+		"no":      false,
+		"null":    nil,
+		"notbool": "true",
+	}
+	cases := []struct {
+		key     string
+		wantVal bool
+		wantOK  bool
+	}{
+		{"yes", true, true},
+		{"no", false, true},
+		{"null", false, false},
+		{"missing", false, false},
+		{"notbool", false, false},
+	}
+	for _, tc := range cases {
+		v, ok := jsonBool(m, tc.key)
+		if v != tc.wantVal || ok != tc.wantOK {
+			t.Errorf("jsonBool(%q) = (%v, %v), want (%v, %v)", tc.key, v, ok, tc.wantVal, tc.wantOK)
+		}
+	}
+}
+
 func TestActivitiesTypes_NoAccount(t *testing.T) {
 	var buf bytes.Buffer
 	g := testGlobals(t, &buf, outfmt.Table, "")


### PR DESCRIPTION
Follow-up polish to #46.

## Summary

- Sort activity types by `typeId` for stable, browsable `table`/`plain` output (the API returns them in an unspecified order).
- Add `HIDDEN` and `RESTRICTED` columns. Both fields are already returned by `/activity-service/activity/activityTypes` and are useful for spotting types that aren't user-selectable. JSON output is unchanged (still the raw payload).
- Extract `parseActivityTypes`, `formatActivityTypeRows`, and `activityTypesHeader` to mirror the existing `parseActivities` / `formatActivityRows` pattern. This lets the row formatter be unit-tested directly instead of going through `os.Stdout`.
- Add a `jsonBool(m, key) (bool, bool)` helper next to `jsonString` / `jsonFloat`, and replace the one-off `formatTrimmable` with a generic `formatYesNo(map, key)` so the same helper drives all three boolean columns.
- Tests: sort order, `formatActivityTypeRows` table content (including the null `parentTypeId` branch that wasn't previously exercised), and `jsonBool` truth table.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Chore (CI, dependencies, tooling)

## Checklist

- [x] \`make fmt\` — code is formatted
- [x] \`make lint\` — no linting errors
- [x] \`make test\` — all tests pass
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title is descriptive and follows conventional format