### PR TITLE
feat: add gccli courses download command

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -432,7 +432,7 @@ gccli activities list --limit 5</pre>
           <div class="feature-card fade-in">
             <div class="feature-icon violet">&#x1f5fa;</div>
             <h3>Courses</h3>
-            <p>List courses, view favorites, get full course detail. Import GPX files as new courses. Send courses directly to your device or delete them.</p>
+            <p>List courses, view favorites, get full course detail, download as FIT or GPX. Import GPX files as new courses. Send courses directly to your device or delete them.</p>
           </div>
           <div class="feature-card fade-in">
             <div class="feature-icon violet">&#x231a;</div>
@@ -610,6 +610,7 @@ gccli activities list --limit 5</pre>
               <div class="cmd-row"><div class="cmd">gccli courses list</div><div class="desc">List your courses</div></div>
               <div class="cmd-row"><div class="cmd">gccli courses favorites</div><div class="desc">List favorite courses</div></div>
               <div class="cmd-row"><div class="cmd">gccli courses detail &lt;id&gt;</div><div class="desc">View course details</div></div>
+              <div class="cmd-row"><div class="cmd">gccli courses download &lt;id&gt; --format fit</div><div class="desc">Download course as FIT or GPX</div></div>
               <div class="cmd-row"><div class="cmd">gccli courses import route.gpx</div><div class="desc">Import GPX as new course (default: cycling, private)</div></div>
               <div class="cmd-row"><div class="cmd">gccli courses import route.gpx --name "Ride"</div><div class="desc">Import with custom name</div></div>
               <div class="cmd-row"><div class="cmd">gccli courses import route.gpx --type hiking</div><div class="desc">Override activity type</div></div>

--- a/internal/cmd/activity_download.go
+++ b/internal/cmd/activity_download.go
@@ -24,7 +24,7 @@ func (c *ActivityDownloadCmd) Run(g *Globals) error {
 		return err
 	}
 
-	format := garminapi.ActivityDownloadFormat(strings.ToLower(c.Format))
+	format := garminapi.DownloadFormat(strings.ToLower(c.Format))
 
 	data, err := client.DownloadActivity(g.Context, c.ID, format)
 	if err != nil {

--- a/internal/cmd/courses.go
+++ b/internal/cmd/courses.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bpauli/gccli/internal/garminapi"
 	"github.com/bpauli/gccli/internal/outfmt"
 )
 
@@ -15,6 +16,7 @@ type CoursesCmd struct {
 	List      CoursesListCmd      `cmd:"" default:"withargs" help:"List courses."`
 	Favorites CoursesFavoritesCmd `cmd:"" help:"List favorite courses."`
 	Detail    CourseDetailCmd     `cmd:"" help:"View course details."`
+	Download  CourseDownloadCmd   `cmd:"" help:"Download course file."`
 	Import    CourseImportCmd     `cmd:"" help:"Import a GPX file as a new course."`
 	Send      CourseSendCmd       `cmd:"" help:"Send a course to a device."`
 	Delete    CourseDeleteCmd     `cmd:"" help:"Delete a course."`
@@ -101,6 +103,39 @@ func (c *CourseDetailCmd) Run(g *Globals) error {
 	}
 
 	return outfmt.WriteJSON(os.Stdout, json.RawMessage(data))
+}
+
+// CourseDownloadCmd downloads a course in a specified format.
+type CourseDownloadCmd struct {
+	ID     string `arg:"" help:"Course ID."`
+	Format string `help:"Download format: fit, gpx." default:"fit" enum:"fit,gpx"`
+	Output string `help:"Output file path (default: course_{id}.{format})." short:"o"`
+}
+
+func (c *CourseDownloadCmd) Run(g *Globals) error {
+	client, err := resolveClient(g)
+	if err != nil {
+		return err
+	}
+
+	format := garminapi.ActivityDownloadFormat(strings.ToLower(c.Format))
+
+	data, err := client.DownloadCourse(g.Context, c.ID, format)
+	if err != nil {
+		return fmt.Errorf("download course: %w", err)
+	}
+
+	outPath := c.Output
+	if outPath == "" {
+		outPath = fmt.Sprintf("course_%s.%s", c.ID, c.Format)
+	}
+
+	if err := os.WriteFile(outPath, data, 0o644); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	g.UI.Successf("Downloaded %s (%d bytes)", outPath, len(data))
+	return nil
 }
 
 // CourseImportCmd imports a GPX file as a new course.

--- a/internal/cmd/courses.go
+++ b/internal/cmd/courses.go
@@ -118,7 +118,7 @@ func (c *CourseDownloadCmd) Run(g *Globals) error {
 		return err
 	}
 
-	format := garminapi.ActivityDownloadFormat(strings.ToLower(c.Format))
+	format := garminapi.DownloadFormat(strings.ToLower(c.Format))
 
 	data, err := client.DownloadCourse(g.Context, c.ID, format)
 	if err != nil {

--- a/internal/garminapi/activities.go
+++ b/internal/garminapi/activities.go
@@ -14,17 +14,6 @@ import (
 	"strings"
 )
 
-// ActivityDownloadFormat represents a supported activity export format.
-type ActivityDownloadFormat string
-
-const (
-	FormatFIT ActivityDownloadFormat = "fit"
-	FormatTCX ActivityDownloadFormat = "tcx"
-	FormatGPX ActivityDownloadFormat = "gpx"
-	FormatKML ActivityDownloadFormat = "kml"
-	FormatCSV ActivityDownloadFormat = "csv"
-)
-
 // CountActivities returns the total number of activities for the authenticated user.
 func (c *Client) CountActivities(ctx context.Context) (int, error) {
 	data, err := c.ConnectAPI(ctx, http.MethodGet, "/activitylist-service/activities/count", nil)
@@ -113,7 +102,7 @@ func (c *Client) SearchActivities(ctx context.Context, start, limit int, startDa
 }
 
 // downloadPath returns the API path for downloading an activity in the given format.
-func downloadPath(activityID string, format ActivityDownloadFormat) (string, error) {
+func downloadPath(activityID string, format DownloadFormat) (string, error) {
 	switch format {
 	case FormatFIT:
 		return "/download-service/files/activity/" + activityID, nil
@@ -131,7 +120,7 @@ func downloadPath(activityID string, format ActivityDownloadFormat) (string, err
 }
 
 // DownloadActivity downloads an activity in the specified format.
-func (c *Client) DownloadActivity(ctx context.Context, activityID string, format ActivityDownloadFormat) ([]byte, error) {
+func (c *Client) DownloadActivity(ctx context.Context, activityID string, format DownloadFormat) ([]byte, error) {
 	path, err := downloadPath(activityID, format)
 	if err != nil {
 		return nil, err

--- a/internal/garminapi/activities_test.go
+++ b/internal/garminapi/activities_test.go
@@ -448,7 +448,7 @@ func TestDownloadActivity_InvalidFormat(t *testing.T) {
 
 func TestDownloadPath(t *testing.T) {
 	tests := []struct {
-		format ActivityDownloadFormat
+		format DownloadFormat
 		want   string
 	}{
 		{FormatFIT, "/download-service/files/activity/123"},

--- a/internal/garminapi/courses.go
+++ b/internal/garminapi/courses.go
@@ -29,6 +29,27 @@ func (c *Client) GetCourseFavorites(ctx context.Context) (json.RawMessage, error
 	return c.ConnectAPI(ctx, http.MethodGet, "/course-service/course/favorites", nil)
 }
 
+// downloadPath returns the API path for downloading a course in the given format.
+func downloadCoursePath(courseID string, format ActivityDownloadFormat) (string, error) {
+	switch format {
+	case FormatFIT:
+		return "/course-service/course/fit/" + courseID + "/0?elevation=true", nil
+	case FormatGPX:
+		return "/course-service/course/gpx/" + courseID, nil
+	default:
+		return "", &InvalidFileFormatError{Format: string(format)}
+	}
+}
+
+// DownloadCourse downloads a course in the specified format.
+func (c *Client) DownloadCourse(ctx context.Context, courseID string, format ActivityDownloadFormat) ([]byte, error) {
+	path, err := downloadCoursePath(courseID, format)
+	if err != nil {
+		return nil, err
+	}
+	return c.Download(ctx, path)
+}
+
 // ImportCourseGPX uploads a GPX file and returns parsed course data.
 func (c *Client) ImportCourseGPX(ctx context.Context, filePath string) (json.RawMessage, error) {
 	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(filePath), "."))

--- a/internal/garminapi/courses.go
+++ b/internal/garminapi/courses.go
@@ -30,7 +30,7 @@ func (c *Client) GetCourseFavorites(ctx context.Context) (json.RawMessage, error
 }
 
 // downloadPath returns the API path for downloading a course in the given format.
-func downloadCoursePath(courseID string, format ActivityDownloadFormat) (string, error) {
+func downloadCoursePath(courseID string, format DownloadFormat) (string, error) {
 	switch format {
 	case FormatFIT:
 		return "/course-service/course/fit/" + courseID + "/0?elevation=true", nil
@@ -42,7 +42,7 @@ func downloadCoursePath(courseID string, format ActivityDownloadFormat) (string,
 }
 
 // DownloadCourse downloads a course in the specified format.
-func (c *Client) DownloadCourse(ctx context.Context, courseID string, format ActivityDownloadFormat) ([]byte, error) {
+func (c *Client) DownloadCourse(ctx context.Context, courseID string, format DownloadFormat) ([]byte, error) {
 	path, err := downloadCoursePath(courseID, format)
 	if err != nil {
 		return nil, err

--- a/internal/garminapi/download_format.go
+++ b/internal/garminapi/download_format.go
@@ -1,6 +1,6 @@
 package garminapi
 
-// DownloadFormat represents a supported activity export format.
+// DownloadFormat represents a supported export format.
 type DownloadFormat string
 
 const (

--- a/internal/garminapi/download_format.go
+++ b/internal/garminapi/download_format.go
@@ -1,0 +1,12 @@
+package garminapi
+
+// DownloadFormat represents a supported activity export format.
+type DownloadFormat string
+
+const (
+	FormatFIT DownloadFormat = "fit"
+	FormatTCX DownloadFormat = "tcx"
+	FormatGPX DownloadFormat = "gpx"
+	FormatKML DownloadFormat = "kml"
+	FormatCSV DownloadFormat = "csv"
+)


### PR DESCRIPTION
## Summary

Added support for downloading a course as FIT or GPX. Useful for downloading public courses.
Refactored ActivityDownloadFormat into DownloadFormat and moved the type to its own file, since it is now also used by the courses download command.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactoring
- [x] Documentation
- [ ] Chore (CI, dependencies, tooling)

## Checklist

- [x] `make fmt` — code is formatted
- [x] `make lint` — no linting errors
- [x] `make test` — all tests pass
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title is descriptive and follows conventional format
