### PR TITLE
feat: expand activity summary fields

### DIFF
--- a/internal/cmd/activity_fields.go
+++ b/internal/cmd/activity_fields.go
@@ -31,6 +31,10 @@ var fieldRegistry = map[string]summaryField{
 		Key: "elevation_gain", Label: "ELEVATION",
 		Format: func(s, _ map[string]any) string { return formatElevation(jsonFloat(s, "elevationGain")) },
 	},
+	"elevation_loss": {
+		Key: "elevation_loss", Label: "ELEVATION LOSS",
+		Format: func(s, _ map[string]any) string { return formatElevation(jsonFloat(s, "elevationLoss")) },
+	},
 	"avg_power": {
 		Key: "avg_power", Label: "AVG POWER",
 		Format: func(s, _ map[string]any) string { return formatPower(jsonFloat(s, "averagePower")) },
@@ -55,19 +59,35 @@ var fieldRegistry = map[string]summaryField{
 		Key: "reps", Label: "REPS",
 		Format: func(s, _ map[string]any) string { return formatCount(jsonFloat(s, "totalExerciseReps")) },
 	},
+	"aerobic_training_effect": {
+		Key: "aerobic_training_effect", Label: "AEROBIC TRAINING EFFECT",
+		Format: func(s, _ map[string]any) string { return formatDecimal(jsonFloat(s, "trainingEffect")) },
+	},
+	"anaerobic_training_effect": {
+		Key: "anaerobic_training_effect", Label: "ANAEROBIC TRAINING EFFECT",
+		Format: func(s, _ map[string]any) string { return formatDecimal(jsonFloat(s, "anaerobicTrainingEffect")) },
+	},
+	"feel": {
+		Key: "feel", Label: "FEEL",
+		Format: func(s, _ map[string]any) string { return formatWorkoutFeel(s) },
+	},
+	"rpe": {
+		Key: "rpe", Label: "RPE",
+		Format: func(s, _ map[string]any) string { return formatRPE(jsonFloat(s, "directWorkoutRpe")) },
+	},
 }
 
 // categoryDefaults maps activity category names to their default field keys.
 var categoryDefaults = map[string][]string{
-	"cycling":           {"distance", "duration", "avg_speed", "elevation_gain", "avg_power"},
-	"running":           {"distance", "duration", "avg_pace", "elevation_gain", "avg_hr"},
-	"fitness_equipment": {"duration", "sets", "reps", "avg_hr", "calories"},
-	"swimming":          {"distance", "duration", "avg_pace", "calories", "avg_hr"},
-	"hiking":            {"distance", "duration", "avg_pace", "elevation_gain", "calories"},
-	"multi_sport":       {"duration", "distance", "calories", "elevation_gain", "avg_speed"},
-	"winter_sports":     {"distance", "duration", "avg_speed", "elevation_gain", "calories"},
-	"water_sports":      {"distance", "duration", "avg_speed", "avg_hr", "calories"},
-	"other":             {"distance", "duration", "avg_speed", "avg_hr", "calories"},
+	"cycling":           {"distance", "duration", "avg_speed", "elevation_gain", "elevation_loss", "avg_power", "aerobic_training_effect", "anaerobic_training_effect", "feel", "rpe"},
+	"running":           {"distance", "duration", "avg_pace", "elevation_gain", "elevation_loss", "avg_hr", "aerobic_training_effect", "anaerobic_training_effect", "feel", "rpe"},
+	"fitness_equipment": {"duration", "sets", "reps", "avg_hr", "calories", "aerobic_training_effect", "anaerobic_training_effect", "feel", "rpe"},
+	"swimming":          {"distance", "duration", "avg_pace", "calories", "avg_hr", "aerobic_training_effect", "anaerobic_training_effect", "feel", "rpe"},
+	"hiking":            {"distance", "duration", "avg_pace", "elevation_gain", "elevation_loss", "calories", "aerobic_training_effect", "anaerobic_training_effect", "feel", "rpe"},
+	"multi_sport":       {"duration", "distance", "calories", "elevation_gain", "elevation_loss", "avg_speed", "aerobic_training_effect", "anaerobic_training_effect", "feel", "rpe"},
+	"winter_sports":     {"distance", "duration", "avg_speed", "elevation_gain", "elevation_loss", "calories", "aerobic_training_effect", "anaerobic_training_effect", "feel", "rpe"},
+	"water_sports":      {"distance", "duration", "avg_speed", "avg_hr", "calories", "aerobic_training_effect", "anaerobic_training_effect", "feel", "rpe"},
+	"other":             {"distance", "duration", "avg_speed", "avg_hr", "calories", "aerobic_training_effect", "anaerobic_training_effect", "feel", "rpe"},
 }
 
 // parentTypeCategories maps Garmin parentTypeId to category name.
@@ -180,4 +200,47 @@ func formatCount(n float64) string {
 		return "-"
 	}
 	return fmt.Sprintf("%d", int(n))
+}
+
+// formatDecimal formats a decimal value to one fractional digit.
+func formatDecimal(n float64) string {
+	if n == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f", n)
+}
+
+// formatRPE converts Garmin's 0-100 workout RPE to a 0-10 scale.
+func formatRPE(n float64) string {
+	if n == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f", n/10)
+}
+
+// formatWorkoutFeel maps Garmin's five-level workout feel scale to labels.
+func formatWorkoutFeel(summary map[string]any) string {
+	value, ok := summary["directWorkoutFeel"]
+	if !ok || value == nil {
+		return "-"
+	}
+	n, ok := value.(float64)
+	if !ok {
+		return "-"
+	}
+
+	switch n {
+	case 0:
+		return "VERY WEAK"
+	case 25:
+		return "WEAK"
+	case 50:
+		return "NORMAL"
+	case 75:
+		return "STRONG"
+	case 100:
+		return "VERY STRONG"
+	default:
+		return fmt.Sprintf("%g", n)
+	}
 }

--- a/internal/cmd/activity_fields_test.go
+++ b/internal/cmd/activity_fields_test.go
@@ -268,24 +268,89 @@ func TestFormatCount(t *testing.T) {
 	}
 }
 
+func TestFormatDecimal(t *testing.T) {
+	tests := []struct {
+		n    float64
+		want string
+	}{
+		{0, "-"},
+		{3.0999999046325684, "3.1"},
+		{4, "4.0"},
+	}
+	for _, tt := range tests {
+		got := formatDecimal(tt.n)
+		if got != tt.want {
+			t.Errorf("formatDecimal(%v) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
+func TestFormatRPE(t *testing.T) {
+	tests := []struct {
+		n    float64
+		want string
+	}{
+		{0, "-"},
+		{30, "3.0"},
+		{75, "7.5"},
+		{100, "10.0"},
+	}
+	for _, tt := range tests {
+		got := formatRPE(tt.n)
+		if got != tt.want {
+			t.Errorf("formatRPE(%v) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
+func TestFormatWorkoutFeel(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary map[string]any
+		want    string
+	}{
+		{"missing", map[string]any{}, "-"},
+		{"null", map[string]any{"directWorkoutFeel": nil}, "-"},
+		{"very weak", map[string]any{"directWorkoutFeel": float64(0)}, "VERY WEAK"},
+		{"weak", map[string]any{"directWorkoutFeel": float64(25)}, "WEAK"},
+		{"normal", map[string]any{"directWorkoutFeel": float64(50)}, "NORMAL"},
+		{"strong", map[string]any{"directWorkoutFeel": float64(75)}, "STRONG"},
+		{"very strong", map[string]any{"directWorkoutFeel": float64(100)}, "VERY STRONG"},
+		{"unknown", map[string]any{"directWorkoutFeel": float64(60)}, "60"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatWorkoutFeel(tt.summary)
+			if got != tt.want {
+				t.Errorf("formatWorkoutFeel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatActivitySummary_CyclingCategory(t *testing.T) {
 	activity := map[string]any{
 		"activityName":    "Afternoon Ride",
 		"activityTypeDTO": map[string]any{"typeKey": "road_biking", "parentTypeId": float64(2)},
 		"summaryDTO": map[string]any{
-			"startTimeLocal": "2024-06-15 14:00:00",
-			"distance":       float64(40000),
-			"duration":       float64(3600),
-			"averageSpeed":   float64(11.111),
-			"elevationGain":  float64(320),
-			"averagePower":   float64(200),
+			"startTimeLocal":          "2024-06-15 14:00:00",
+			"distance":                float64(40000),
+			"duration":                float64(3600),
+			"averageSpeed":            float64(11.111),
+			"elevationGain":           float64(320),
+			"elevationLoss":           float64(305),
+			"averagePower":            float64(200),
+			"trainingEffect":          float64(3.4),
+			"anaerobicTrainingEffect": float64(1.2),
+			"directWorkoutFeel":       float64(75),
+			"directWorkoutRpe":        float64(30),
 		},
 	}
 
 	rows := formatActivitySummary(activity, nil)
-	// 3 fixed + 5 cycling fields
-	if len(rows) != 8 {
-		t.Fatalf("expected 8 rows, got %d", len(rows))
+	// 3 fixed + 10 cycling fields
+	if len(rows) != 13 {
+		t.Fatalf("expected 13 rows, got %d", len(rows))
 	}
 
 	expected := []struct {
@@ -299,7 +364,12 @@ func TestFormatActivitySummary_CyclingCategory(t *testing.T) {
 		{"DURATION", "1:00:00"},
 		{"AVG SPEED", "40.0 km/h"},
 		{"ELEVATION", "320 m"},
+		{"ELEVATION LOSS", "305 m"},
 		{"AVG POWER", "200 W"},
+		{"AEROBIC TRAINING EFFECT", "3.4"},
+		{"ANAEROBIC TRAINING EFFECT", "1.2"},
+		{"FEEL", "STRONG"},
+		{"RPE", "3.0"},
 	}
 
 	for i, exp := range expected {
@@ -317,19 +387,23 @@ func TestFormatActivitySummary_StrengthCategory(t *testing.T) {
 		"activityName":    "Chest Day",
 		"activityTypeDTO": map[string]any{"typeKey": "strength_training", "parentTypeId": float64(29)},
 		"summaryDTO": map[string]any{
-			"startTimeLocal":    "2024-06-15 10:00:00",
-			"duration":          float64(2700),
-			"activeSets":        float64(12),
-			"totalExerciseReps": float64(96),
-			"averageHR":         float64(120),
-			"calories":          float64(280),
+			"startTimeLocal":          "2024-06-15 10:00:00",
+			"duration":                float64(2700),
+			"activeSets":              float64(12),
+			"totalExerciseReps":       float64(96),
+			"averageHR":               float64(120),
+			"calories":                float64(280),
+			"trainingEffect":          float64(2.5),
+			"anaerobicTrainingEffect": float64(1.8),
+			"directWorkoutFeel":       float64(50),
+			"directWorkoutRpe":        float64(40),
 		},
 	}
 
 	rows := formatActivitySummary(activity, nil)
-	// 3 fixed + 5 fitness_equipment fields
-	if len(rows) != 8 {
-		t.Fatalf("expected 8 rows, got %d", len(rows))
+	// 3 fixed + 9 fitness_equipment fields
+	if len(rows) != 12 {
+		t.Fatalf("expected 12 rows, got %d", len(rows))
 	}
 
 	expected := []struct {
@@ -344,6 +418,10 @@ func TestFormatActivitySummary_StrengthCategory(t *testing.T) {
 		{"REPS", "96"},
 		{"AVG HR", "120 bpm"},
 		{"CALORIES", "280"},
+		{"AEROBIC TRAINING EFFECT", "2.5"},
+		{"ANAEROBIC TRAINING EFFECT", "1.8"},
+		{"FEEL", "NORMAL"},
+		{"RPE", "4.0"},
 	}
 
 	for i, exp := range expected {
@@ -384,6 +462,51 @@ func TestFormatActivitySummary_ConfigOverride(t *testing.T) {
 	}
 	if rows[5][0] != "CALORIES" {
 		t.Errorf("row 5 label = %q, want CALORIES", rows[5][0])
+	}
+}
+
+func TestFormatActivitySummary_NewFieldConfigOverride(t *testing.T) {
+	activity := map[string]any{
+		"activityName":    "Morning Run",
+		"activityTypeDTO": map[string]any{"typeKey": "running", "parentTypeId": float64(17)},
+		"summaryDTO": map[string]any{
+			"startTimeLocal":          "2024-06-15 07:30:00",
+			"elevationLoss":           float64(117.55),
+			"trainingEffect":          float64(3.1),
+			"anaerobicTrainingEffect": float64(0.8),
+			"directWorkoutFeel":       float64(75),
+			"directWorkoutRpe":        float64(30),
+		},
+	}
+
+	overrides := map[string][]string{
+		"running": {
+			"elevation_loss",
+			"aerobic_training_effect",
+			"anaerobic_training_effect",
+			"feel",
+			"rpe",
+		},
+	}
+	rows := formatActivitySummary(activity, overrides)
+
+	expected := [][]string{
+		{"NAME", "Morning Run"},
+		{"TYPE", "running"},
+		{"DATE", "2024-06-15"},
+		{"ELEVATION LOSS", "117 m"},
+		{"AEROBIC TRAINING EFFECT", "3.1"},
+		{"ANAEROBIC TRAINING EFFECT", "0.8"},
+		{"FEEL", "STRONG"},
+		{"RPE", "3.0"},
+	}
+	if len(rows) != len(expected) {
+		t.Fatalf("expected %d rows, got %d", len(expected), len(rows))
+	}
+	for i := range expected {
+		if rows[i][0] != expected[i][0] || rows[i][1] != expected[i][1] {
+			t.Errorf("row %d = %v, want %v", i, rows[i], expected[i])
+		}
 	}
 }
 

--- a/internal/cmd/activity_test.go
+++ b/internal/cmd/activity_test.go
@@ -501,21 +501,26 @@ func TestFormatActivitySummary(t *testing.T) {
 		"activityName":    "Morning Run",
 		"activityTypeDTO": map[string]any{"typeKey": "running", "parentTypeId": float64(17)},
 		"summaryDTO": map[string]any{
-			"startTimeLocal": "2024-06-15 07:30:00",
-			"distance":       float64(5123.45),
-			"duration":       float64(1800),
-			"averageSpeed":   float64(2.847),
-			"elevationGain":  float64(85),
-			"averageHR":      float64(145),
-			"maxHR":          float64(172),
-			"calories":       float64(350),
+			"startTimeLocal":          "2024-06-15 07:30:00",
+			"distance":                float64(5123.45),
+			"duration":                float64(1800),
+			"averageSpeed":            float64(2.847),
+			"elevationGain":           float64(85),
+			"elevationLoss":           float64(79),
+			"averageHR":               float64(145),
+			"maxHR":                   float64(172),
+			"calories":                float64(350),
+			"trainingEffect":          float64(3.1),
+			"anaerobicTrainingEffect": float64(0.8),
+			"directWorkoutFeel":       float64(75),
+			"directWorkoutRpe":        float64(30),
 		},
 	}
 
-	// Running category default fields: distance, duration, avg_pace, elevation_gain, avg_hr
+	// Running category includes performance and subjective effort fields.
 	rows := formatActivitySummary(activity, nil)
-	if len(rows) != 8 {
-		t.Fatalf("expected 8 rows (3 fixed + 5 fields), got %d", len(rows))
+	if len(rows) != 13 {
+		t.Fatalf("expected 13 rows (3 fixed + 10 fields), got %d", len(rows))
 	}
 
 	expected := []struct {
@@ -529,7 +534,12 @@ func TestFormatActivitySummary(t *testing.T) {
 		{"DURATION", "30:00"},
 		{"AVG PACE", "5:51 /km"},
 		{"ELEVATION", "85 m"},
+		{"ELEVATION LOSS", "79 m"},
 		{"AVG HR", "145 bpm"},
+		{"AEROBIC TRAINING EFFECT", "3.1"},
+		{"ANAEROBIC TRAINING EFFECT", "0.8"},
+		{"FEEL", "STRONG"},
+		{"RPE", "3.0"},
 	}
 
 	for i, exp := range expected {
@@ -547,14 +557,14 @@ func TestFormatActivitySummary_MissingFields(t *testing.T) {
 		"activityName": "Strength Training",
 	}
 
-	// Falls back to "other" category: distance, duration, avg_speed, avg_hr, calories
+	// Falls back to the "other" category.
 	rows := formatActivitySummary(activity, nil)
-	if len(rows) != 8 {
-		t.Fatalf("expected 8 rows (3 fixed + 5 fields), got %d", len(rows))
+	if len(rows) != 12 {
+		t.Fatalf("expected 12 rows (3 fixed + 9 fields), got %d", len(rows))
 	}
 
 	// Missing numeric fields should show "-".
-	for _, idx := range []int{3, 4, 5, 6, 7} {
+	for _, idx := range []int{3, 4, 5, 6, 7, 8, 9, 10, 11} {
 		if rows[idx][1] != "-" {
 			t.Errorf("row %d (%s): expected '-', got %q", idx, rows[idx][0], rows[idx][1])
 		}


### PR DESCRIPTION
## Summary

- add elevation loss, aerobic training effect, anaerobic training effect, workout feel, and RPE to activity summaries
- expose the new values through the activity summary field registry and category defaults so they can also be selected through `activity_summary` configuration
- normalize Garmin's workout RPE from its 0-100 representation to a 0-10 scale and map the five workout-feel values to readable labels

The current summary field registry does not allow these additional details to be displayed. RPE and workout feel are especially important because Garmin returns them in `summaryDTO`, but not in the activity details DTO, so they cannot be fetched through another activity command.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Chore (CI, dependencies, tooling)

## Testing

- `go test ./internal/cmd/...`
- `gofmt` and `git diff --check`
- `go test ./...` passes all relevant packages; two existing Windows permission assertions fail in `internal/config` (`0600` mode and unreadable-file behavior)

## Checklist

- [x] Code is formatted
- [x] Relevant tests pass
- [x] Commit messages follow Conventional Commits
- [x] PR title is descriptive and follows conventional format