### PR TITLE
test(courses): add DownloadCourse tests and finish docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Fast, script-friendly CLI for Garmin Connect. Access activities, health data, bo
 - **Health Data** — daily summaries, steps, heart rate, resting HR, sleep, stress, HRV, SpO2, respiration, body battery, floors, training readiness/status, VO2max, fitness age, race predictions, endurance/hill scores, intensity minutes, lactate threshold, cycling FTP
 - **Body Composition** — weight tracking, body fat, muscle mass, blood pressure, FIT file encoding for composition uploads
 - **Workouts** — list, view, download as FIT, upload from JSON, create with sport types and targets (pace/HR/power/cadence), schedule (add/list/remove), delete
-- **Courses** — list courses, view favorites, get full course detail, import GPX files as new courses, send courses directly to a device, delete courses
+- **Courses** — list courses, view favorites, get full course detail, download as FIT/GPX, import GPX files as new courses, send courses directly to a device, delete courses
 - **Devices** — list registered devices, view settings, solar data, alarms, primary/last-used device
 - **Gear** — list gear, usage stats, linked activities, defaults per activity type, link/unlink to activities
 - **Goals & Badges** — active goals, earned/available/in-progress badges, challenges, personal records
@@ -480,6 +480,9 @@ gccli exercises list --json
 gccli courses list                             # List all courses
 gccli courses favorites                        # List favorite courses
 gccli courses detail <id>                      # View full course detail
+gccli courses download <id>                    # Download course as FIT (default)
+gccli courses download <id> --format gpx       # Download course as GPX
+gccli courses download <id> -o ride.fit        # Download to a custom path
 gccli courses import route.gpx                 # Import GPX as new course (default: cycling, private)
 gccli courses import route.gpx --name "Ride"   # Import with custom name
 gccli courses import route.gpx --type hiking   # Override activity type

--- a/internal/garminapi/courses.go
+++ b/internal/garminapi/courses.go
@@ -29,7 +29,7 @@ func (c *Client) GetCourseFavorites(ctx context.Context) (json.RawMessage, error
 	return c.ConnectAPI(ctx, http.MethodGet, "/course-service/course/favorites", nil)
 }
 
-// downloadPath returns the API path for downloading a course in the given format.
+// downloadCoursePath returns the API path for downloading a course in the given format.
 func downloadCoursePath(courseID string, format DownloadFormat) (string, error) {
 	switch format {
 	case FormatFIT:

--- a/internal/garminapi/courses_test.go
+++ b/internal/garminapi/courses_test.go
@@ -516,3 +516,120 @@ func TestSendCourseToDevice_ServerError(t *testing.T) {
 		t.Fatalf("expected GarminAPIError, got %T: %v", err, err)
 	}
 }
+
+// --- DownloadCourse tests ---
+
+func TestDownloadCourse_FIT(t *testing.T) {
+	want := []byte("raw-fit-bytes")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/course-service/course/fit/12345/0" {
+			t.Errorf("path = %s, want /course-service/course/fit/12345/0", r.URL.Path)
+		}
+		if r.URL.Query().Get("elevation") != "true" {
+			t.Errorf("elevation = %q, want true", r.URL.Query().Get("elevation"))
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		_, _ = w.Write(want)
+	})
+
+	_, client := testServer(t, handler)
+	got, err := client.DownloadCourse(context.Background(), "12345", FormatFIT)
+	if err != nil {
+		t.Fatalf("DownloadCourse: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+func TestDownloadCourse_GPX(t *testing.T) {
+	want := []byte("<gpx/>")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/course-service/course/gpx/12345" {
+			t.Errorf("path = %s, want /course-service/course/gpx/12345", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		_, _ = w.Write(want)
+	})
+
+	_, client := testServer(t, handler)
+	got, err := client.DownloadCourse(context.Background(), "12345", FormatGPX)
+	if err != nil {
+		t.Fatalf("DownloadCourse: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+func TestDownloadCourse_InvalidFormat(t *testing.T) {
+	_, client := testServer(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	_, err := client.DownloadCourse(context.Background(), "12345", FormatTCX)
+	if err == nil {
+		t.Fatal("expected error for unsupported course format")
+	}
+
+	var fmtErr *InvalidFileFormatError
+	if !errors.As(err, &fmtErr) {
+		t.Fatalf("expected InvalidFileFormatError, got %T: %v", err, err)
+	}
+	if fmtErr.Format != "tcx" {
+		t.Errorf("Format = %q, want tcx", fmtErr.Format)
+	}
+}
+
+func TestDownloadCourse_ServerError(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	})
+
+	_, client := testServer(t, handler)
+	_, err := client.DownloadCourse(context.Background(), "12345", FormatGPX)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// --- downloadCoursePath tests ---
+
+func TestDownloadCoursePath(t *testing.T) {
+	tests := []struct {
+		format DownloadFormat
+		want   string
+	}{
+		{FormatFIT, "/course-service/course/fit/777/0?elevation=true"},
+		{FormatGPX, "/course-service/course/gpx/777"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.format), func(t *testing.T) {
+			got, err := downloadCoursePath("777", tt.format)
+			if err != nil {
+				t.Fatalf("downloadCoursePath: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("downloadCoursePath = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDownloadCoursePath_Invalid(t *testing.T) {
+	for _, format := range []DownloadFormat{FormatTCX, FormatKML, FormatCSV, "xyz"} {
+		t.Run(string(format), func(t *testing.T) {
+			_, err := downloadCoursePath("777", format)
+			if err == nil {
+				t.Fatalf("expected error for format %q", format)
+			}
+			var fmtErr *InvalidFileFormatError
+			if !errors.As(err, &fmtErr) {
+				t.Fatalf("expected InvalidFileFormatError, got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/skills/gccli/SKILL.md
+++ b/skills/gccli/SKILL.md
@@ -105,6 +105,8 @@ Common commands
 - List courses: `gccli courses list`
 - Favorite courses: `gccli courses favorites`
 - Course detail: `gccli courses detail <id>`
+- Download course (FIT): `gccli courses download <id> --format fit`
+- Download course (GPX): `gccli courses download <id> --format gpx --output route.gpx`
 - Import course from GPX (default: cycling, private): `gccli courses import route.gpx`
 - Import course with name: `gccli courses import route.gpx --name "Sunday Ride"`
 - Import course with type: `gccli courses import route.gpx --type gravel_cycling`


### PR DESCRIPTION
## Summary

Follow-up to #51 addressing review findings:

- Add unit tests in `internal/garminapi/courses_test.go` for `Client.DownloadCourse` (FIT, GPX, server error) and `downloadCoursePath` (FIT/GPX paths plus `InvalidFileFormatError` for activity-only formats like `tcx`, `kml`, `csv`).
- Fix the doc comment on `downloadCoursePath` so it starts with the function name (was `// downloadPath ...`).
- Add `gccli courses download` examples to `README.md` (feature bullet + command section) and `skills/gccli/SKILL.md`, matching the `docs/index.html` update that landed with #51.

## Test plan

- [x] `make fmt`
- [x] `make lint` (0 issues)
- [x] `make test` (all packages pass with `-race`)