### PR TITLE
feat: add workouts update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ gccli workouts list --limit 20
 gccli workouts detail <id>
 gccli workouts download <id> --output workout.fit
 gccli workouts upload ./workout.json   # See JSON structure below
+gccli workouts update <id> ./workout.json   # Replace an existing workout, keeping its ID
 gccli workouts schedule add <id> <YYYY-MM-DD>
 gccli workouts schedule list <YYYY-MM-DD>
 gccli workouts schedule list --start 2024-06-01 --end 2024-06-30

--- a/docs/index.html
+++ b/docs/index.html
@@ -702,6 +702,7 @@ gccli activities list --limit 5</pre>
               <div class="cmd-row"><div class="cmd">gccli workouts detail &lt;id&gt;</div><div class="desc">View workout details</div></div>
               <div class="cmd-row"><div class="cmd">gccli workouts download &lt;id&gt; --output workout.fit</div><div class="desc">Download workout as FIT</div></div>
               <div class="cmd-row"><div class="cmd">gccli workouts upload ./workout.json</div><div class="desc">Upload workout from JSON</div></div>
+              <div class="cmd-row"><div class="cmd">gccli workouts update &lt;id&gt; ./workout.json</div><div class="desc">Update workout in place, keeping its ID</div></div>
               <div class="cmd-row"><div class="cmd">gccli workouts create "Name" --type run --step "warmup:5m" ...</div><div class="desc">Create with pace/HR/power targets</div></div>
               <div class="cmd-row"><div class="cmd">gccli workouts schedule add &lt;id&gt; &lt;YYYY-MM-DD&gt;</div><div class="desc">Schedule workout on a date</div></div>
               <div class="cmd-row"><div class="cmd">gccli workouts schedule list &lt;YYYY-MM-DD&gt;</div><div class="desc">List scheduled workouts for a date</div></div>

--- a/internal/cmd/workouts.go
+++ b/internal/cmd/workouts.go
@@ -15,6 +15,7 @@ type WorkoutsCmd struct {
 	Detail   WorkoutDetailCmd   `cmd:"" help:"View workout details."`
 	Download WorkoutDownloadCmd `cmd:"" help:"Download workout as FIT file."`
 	Upload   WorkoutUploadCmd   `cmd:"" help:"Upload workout from JSON file."`
+	Update   WorkoutUpdateCmd   `cmd:"" help:"Update an existing workout from a JSON file."`
 	Create   WorkoutCreateCmd   `cmd:"" help:"Create a workout with sport type and optional targets."`
 	Schedule WorkoutScheduleCmd `cmd:"" help:"Manage scheduled workouts."`
 	Delete   WorkoutDeleteCmd   `cmd:"" help:"Delete a workout."`
@@ -135,6 +136,41 @@ func (c *WorkoutUploadCmd) Run(g *Globals) error {
 	}
 
 	g.UI.Successf("Uploaded workout from %s", c.File)
+	return nil
+}
+
+// WorkoutUpdateCmd updates an existing workout from a JSON file.
+type WorkoutUpdateCmd struct {
+	ID   string `arg:"" help:"Workout ID to update."`
+	File string `arg:"" help:"Path to workout JSON file." type:"existingfile"`
+}
+
+func (c *WorkoutUpdateCmd) Run(g *Globals) error {
+	client, err := resolveClient(g)
+	if err != nil {
+		return err
+	}
+
+	jsonData, err := os.ReadFile(c.File)
+	if err != nil {
+		return fmt.Errorf("read file: %w", err)
+	}
+
+	// Validate that the file contains valid JSON.
+	if !json.Valid(jsonData) {
+		return fmt.Errorf("invalid JSON in %s", c.File)
+	}
+
+	data, err := client.UpdateWorkout(g.Context, c.ID, jsonData)
+	if err != nil {
+		return fmt.Errorf("update workout: %w", err)
+	}
+
+	if outfmt.IsJSON(g.Context) {
+		return outfmt.WriteJSON(os.Stdout, json.RawMessage(data))
+	}
+
+	g.UI.Successf("Updated workout %s from %s", c.ID, c.File)
 	return nil
 }
 

--- a/internal/cmd/workouts_test.go
+++ b/internal/cmd/workouts_test.go
@@ -33,6 +33,18 @@ func workoutsTestServer(t *testing.T) *httptest.Server {
 		case http.MethodGet:
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"workoutId":42,"workoutName":"Tempo Run","sportType":{"sportTypeKey":"running"}}`))
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			var payload map[string]any
+			if err := json.Unmarshal(body, &payload); err != nil {
+				http.Error(w, "bad json", http.StatusBadRequest)
+				return
+			}
+			// The workout keeps its original ID on update.
+			payload["workoutId"] = float64(42)
+			resp, _ := json.Marshal(payload)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(resp)
 		case http.MethodDelete:
 			w.WriteHeader(http.StatusNoContent)
 		default:
@@ -131,6 +143,13 @@ func TestExecute_WorkoutsDownloadHelp(t *testing.T) {
 
 func TestExecute_WorkoutsUploadHelp(t *testing.T) {
 	code := Execute([]string{"workouts", "upload", "--help"}, "1.0.0", "abc123", "2024-01-01")
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}
+
+func TestExecute_WorkoutsUpdateHelp(t *testing.T) {
+	code := Execute([]string{"workouts", "update", "--help"}, "1.0.0", "abc123", "2024-01-01")
 	if code != 0 {
 		t.Fatalf("expected exit code 0, got %d", code)
 	}
@@ -1120,5 +1139,117 @@ func TestWorkoutOwner(t *testing.T) {
 				t.Errorf("workoutOwner() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// --- WorkoutUpdateCmd tests ---
+
+func TestWorkoutUpdate_NoAccount(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "workout.json")
+	if err := os.WriteFile(tmpFile, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "")
+	cmd := &WorkoutUpdateCmd{ID: "42", File: tmpFile}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no account specified") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWorkoutUpdate_Success(t *testing.T) {
+	server := workoutsTestServer(t)
+	defer server.Close()
+
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	overrideNewClient(t, server)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	tmpFile := filepath.Join(t.TempDir(), "workout.json")
+	workoutJSON := `{"workoutName":"Tempo Run v2","sportType":{"sportTypeKey":"running"}}`
+	if err := os.WriteFile(tmpFile, []byte(workoutJSON), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "test@example.com")
+	cmd := &WorkoutUpdateCmd{ID: "42", File: tmpFile}
+	if err := cmd.Run(g); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Updated workout 42") {
+		t.Fatalf("expected 'Updated workout 42' message, got: %q", buf.String())
+	}
+}
+
+func TestWorkoutUpdate_JSON(t *testing.T) {
+	server := workoutsTestServer(t)
+	defer server.Close()
+
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	overrideNewClient(t, server)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	tmpFile := filepath.Join(t.TempDir(), "workout.json")
+	workoutJSON := `{"workoutName":"Tempo Run v2","sportType":{"sportTypeKey":"running"}}`
+	if err := os.WriteFile(tmpFile, []byte(workoutJSON), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.JSON, "test@example.com")
+	cmd := &WorkoutUpdateCmd{ID: "42", File: tmpFile}
+	if err := cmd.Run(g); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestWorkoutUpdate_InvalidJSON(t *testing.T) {
+	server := workoutsTestServer(t)
+	defer server.Close()
+
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	overrideNewClient(t, server)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	tmpFile := filepath.Join(t.TempDir(), "workout.json")
+	if err := os.WriteFile(tmpFile, []byte("not json at all"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "test@example.com")
+	cmd := &WorkoutUpdateCmd{ID: "42", File: tmpFile}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid JSON") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWorkoutUpdate_ReadFileError(t *testing.T) {
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "test@example.com")
+	cmd := &WorkoutUpdateCmd{ID: "42", File: filepath.Join(t.TempDir(), "missing.json")}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "read file") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/garminapi/workouts.go
+++ b/internal/garminapi/workouts.go
@@ -30,6 +30,12 @@ func (c *Client) UploadWorkout(ctx context.Context, workoutJSON json.RawMessage)
 	return c.ConnectAPI(ctx, http.MethodPost, "/workout-service/workout", bytes.NewReader(workoutJSON))
 }
 
+// UpdateWorkout replaces an existing workout with the given JSON payload.
+// The workout keeps its ID, so any calendar schedule referencing it stays intact.
+func (c *Client) UpdateWorkout(ctx context.Context, workoutID string, workoutJSON json.RawMessage) (json.RawMessage, error) {
+	return c.ConnectAPI(ctx, http.MethodPut, "/workout-service/workout/"+workoutID, bytes.NewReader(workoutJSON))
+}
+
 // ScheduleWorkout schedules a workout on a calendar date.
 func (c *Client) ScheduleWorkout(ctx context.Context, workoutID, date string) (json.RawMessage, error) {
 	body, err := json.Marshal(map[string]string{"date": date})

--- a/internal/garminapi/workouts_test.go
+++ b/internal/garminapi/workouts_test.go
@@ -418,3 +418,72 @@ func TestDownloadWorkout_401WithRefresh(t *testing.T) {
 		t.Errorf("expected 2 calls, got %d", calls)
 	}
 }
+
+// --- UpdateWorkout tests ---
+
+func TestUpdateWorkout_Success(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/workout-service/workout/42" {
+			t.Errorf("path = %s, want /workout-service/workout/42", r.URL.Path)
+		}
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("unmarshal body: %v", err)
+		}
+		if payload["workoutName"] != "Updated Workout" {
+			t.Errorf("workoutName = %v, want Updated Workout", payload["workoutName"])
+		}
+
+		_, _ = w.Write([]byte(`{"workoutId":42,"workoutName":"Updated Workout"}`))
+	})
+
+	_, client := testServer(t, handler)
+	data, err := client.UpdateWorkout(context.Background(), "42", json.RawMessage(`{"workoutName":"Updated Workout"}`))
+	if err != nil {
+		t.Fatalf("UpdateWorkout: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	// The workout must keep its original ID so schedules stay intact.
+	if got["workoutId"] != float64(42) {
+		t.Errorf("workoutId = %v, want 42", got["workoutId"])
+	}
+}
+
+func TestUpdateWorkout_ServerError(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("error"))
+	})
+
+	_, client := testServer(t, handler)
+	_, err := client.UpdateWorkout(context.Background(), "42", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUpdateWorkout_NotFound(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"workout not found"}`))
+	})
+
+	_, client := testServer(t, handler)
+	_, err := client.UpdateWorkout(context.Background(), "999", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error for unknown workout")
+	}
+}

--- a/skills/gccli/SKILL.md
+++ b/skills/gccli/SKILL.md
@@ -94,6 +94,7 @@ Common commands
 - Workout detail: `gccli workouts detail <id>`
 - Download workout (FIT): `gccli workouts download <id> --output workout.fit`
 - Upload workout (JSON): `gccli workouts upload ./workout.json`
+- Update workout (JSON): `gccli workouts update <id> ./workout.json` — replaces the workout in place, keeping its ID and any existing schedule
 - Schedule workout: `gccli workouts schedule add <id> 2024-06-20`
 - List scheduled workouts: `gccli workouts schedule list 2024-06-20`
 - List scheduled workouts in range: `gccli workouts schedule list --start 2024-06-01 --end 2024-06-30`


### PR DESCRIPTION
## Summary

Adds `gccli workouts update <id> <file>`, which replaces an existing workout in place via `PUT /workout-service/workout/{id}`.

## Motivation

There is currently no way to modify an existing workout. The only path is `workouts delete` + `workouts upload`, which has two side effects:

1. **The workout gets a new ID** — any stored reference to the old ID goes stale.
2. **The calendar entry is dropped** — the workout must be re-scheduled afterwards.

For anyone generating workouts programmatically and iterating on them (adjusting loads, fixing a step, tweaking targets), every small edit turns into a delete → upload → re-schedule cycle plus bookkeeping for the changed ID.

`workouts update` keeps both the ID and the existing schedule, so an edit is a single call.

## Changes

- **`internal/garminapi`**: `Client.UpdateWorkout(ctx, workoutID, workoutJSON)` — `PUT /workout-service/workout/{id}`
- **`internal/cmd`**: `WorkoutUpdateCmd`, mirroring `WorkoutUploadCmd` (JSON validation before the request, `--json` passthrough, success message)
- **Docs**: `README.md`, `skills/gccli/SKILL.md`, `docs/index.html` — all three updated per CONTRIBUTING

## Tests

7 new tests, following existing patterns:

- **Command** (4): no-account, success, `--json`, invalid JSON, missing file
- **API** (3): success (asserts `PUT` + path + payload, and that the returned `workoutId` is unchanged), server error, 404

The shared `workoutsTestServer` mock gained a `PUT` case on `/workout-service/workout/42` that echoes the payload back with the original ID.

`make fmt` and `make test` pass.

> Note on `make lint`: it currently reports 7 pre-existing `typecheck` issues in `internal/garminauth/di.go` and `di_test.go` on a clean `main` as well (`export data version 4 is greater than maximum supported version 2` — golangci-lint vs the local Go toolchain). Unrelated to this change.

## Manual verification

Tested against the live Garmin Connect API:

1. Fetched an existing scheduled workout, changed its description, ran `workouts update <id> <file>`
2. Re-read from the server: description updated, **workout ID unchanged**, **calendar schedule still intact**
3. Restored the original payload with a second `update` — clean round-trip