### PR TITLE
fix(workouts): set workoutId from the update ID argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Fast, script-friendly CLI for Garmin Connect. Access activities, health data, bo
 - **Exercise Catalog** — browse Garmin's exercise categories and exercises for strength training
 - **Health Data** — daily summaries, steps, heart rate, resting HR, sleep, stress, HRV, SpO2, respiration, body battery, floors, training readiness/status, VO2max, fitness age, race predictions, endurance/hill scores, intensity minutes, lactate threshold, cycling FTP
 - **Body Composition** — weight tracking, body fat, muscle mass, blood pressure, FIT file encoding for composition uploads
-- **Workouts** — list, view, download as FIT, upload from JSON, create with sport types and targets (pace/HR/power/cadence), schedule (add/list/remove), delete
+- **Workouts** — list, view, download as FIT, upload from JSON, update in place from JSON, create with sport types and targets (pace/HR/power/cadence), schedule (add/list/remove), delete
 - **Courses** — list courses, view favorites, get full course detail, download as FIT/GPX, import GPX files as new courses, send courses directly to a device, delete courses
 - **Devices** — list registered devices, view settings, solar data, alarms, primary/last-used device
 - **Gear** — list gear, usage stats, linked activities, defaults per activity type, link/unlink to activities
@@ -439,6 +439,16 @@ gccli workouts create "Full Body" --type strength \
   --step "run:30m" \
   --step "cooldown:5m"
 ```
+
+**Updating a workout in place.** `gccli workouts update` sends a full replacement, not a patch: whatever the file leaves out is gone from the workout. Start from the current server copy rather than from a hand-written fragment:
+
+```bash
+gccli workouts detail 123456 > workout.json
+# edit workout.json
+gccli workouts update 123456 workout.json
+```
+
+The workout keeps its ID and any calendar entries that point at it. `workoutId` in the file is set from the ID argument before the request goes out, so a payload written for `upload` works as-is; if the file already names a different workout, gccli warns and still updates the one given on the command line.
 
 **Workout JSON structure** for `gccli workouts upload`:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -464,7 +464,7 @@ gccli activities list --limit 5</pre>
           <div class="feature-card fade-in">
             <div class="feature-icon orange">&#x1f4aa;</div>
             <h3>Workouts</h3>
-            <p>Create with pace/HR/power/cadence targets, schedule to calendar, download as FIT, upload from JSON. Running, cycling, strength, and more.</p>
+            <p>Create with pace/HR/power/cadence targets, schedule to calendar, download as FIT, upload from JSON, update in place without losing the ID or schedule. Running, cycling, strength, and more.</p>
           </div>
           <div class="feature-card fade-in">
             <div class="feature-icon rose">&#x2696;</div>
@@ -702,7 +702,7 @@ gccli activities list --limit 5</pre>
               <div class="cmd-row"><div class="cmd">gccli workouts detail &lt;id&gt;</div><div class="desc">View workout details</div></div>
               <div class="cmd-row"><div class="cmd">gccli workouts download &lt;id&gt; --output workout.fit</div><div class="desc">Download workout as FIT</div></div>
               <div class="cmd-row"><div class="cmd">gccli workouts upload ./workout.json</div><div class="desc">Upload workout from JSON</div></div>
-              <div class="cmd-row"><div class="cmd">gccli workouts update &lt;id&gt; ./workout.json</div><div class="desc">Update workout in place, keeping its ID</div></div>
+              <div class="cmd-row"><div class="cmd">gccli workouts update &lt;id&gt; ./workout.json</div><div class="desc">Replace a workout in place, keeping its ID and schedule</div></div>
               <div class="cmd-row"><div class="cmd">gccli workouts create "Name" --type run --step "warmup:5m" ...</div><div class="desc">Create with pace/HR/power targets</div></div>
               <div class="cmd-row"><div class="cmd">gccli workouts schedule add &lt;id&gt; &lt;YYYY-MM-DD&gt;</div><div class="desc">Schedule workout on a date</div></div>
               <div class="cmd-row"><div class="cmd">gccli workouts schedule list &lt;YYYY-MM-DD&gt;</div><div class="desc">List scheduled workouts for a date</div></div>

--- a/internal/cmd/workouts.go
+++ b/internal/cmd/workouts.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bpauli/gccli/internal/outfmt"
@@ -146,6 +148,10 @@ type WorkoutUpdateCmd struct {
 }
 
 func (c *WorkoutUpdateCmd) Run(g *Globals) error {
+	if _, err := strconv.ParseInt(c.ID, 10, 64); err != nil {
+		return fmt.Errorf("invalid workout ID: %w", err)
+	}
+
 	client, err := resolveClient(g)
 	if err != nil {
 		return err
@@ -156,12 +162,15 @@ func (c *WorkoutUpdateCmd) Run(g *Globals) error {
 		return fmt.Errorf("read file: %w", err)
 	}
 
-	// Validate that the file contains valid JSON.
-	if !json.Valid(jsonData) {
-		return fmt.Errorf("invalid JSON in %s", c.File)
+	payload, replaced, err := setWorkoutID(jsonData, c.ID)
+	if err != nil {
+		return fmt.Errorf("%s: %w", c.File, err)
+	}
+	if replaced != "" {
+		g.UI.Warnf("Workout JSON has workoutId %s, updating workout %s instead", replaced, c.ID)
 	}
 
-	data, err := client.UpdateWorkout(g.Context, c.ID, jsonData)
+	data, err := client.UpdateWorkout(g.Context, c.ID, payload)
 	if err != nil {
 		return fmt.Errorf("update workout: %w", err)
 	}
@@ -172,6 +181,32 @@ func (c *WorkoutUpdateCmd) Run(g *Globals) error {
 
 	g.UI.Successf("Updated workout %s from %s", c.ID, c.File)
 	return nil
+}
+
+// setWorkoutID returns the payload with workoutId set to workoutID. Garmin
+// resolves the update by the ID in the request path, so the body must carry the
+// same one. A payload written for "workouts upload" has no workoutId at all.
+// The second return value holds the ID that was in the payload when it differed
+// from workoutID, so the caller can warn about the mismatch.
+func setWorkoutID(payload []byte, workoutID string) (json.RawMessage, string, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return nil, "", fmt.Errorf("invalid JSON workout object: %w", err)
+	}
+
+	var replaced string
+	if existing, ok := fields["workoutId"]; ok {
+		if id := strings.TrimSpace(strings.Trim(string(existing), `"`)); id != workoutID && id != "null" {
+			replaced = id
+		}
+	}
+
+	fields["workoutId"] = json.RawMessage(workoutID)
+	updated, err := json.Marshal(fields)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal workout: %w", err)
+	}
+	return updated, replaced, nil
 }
 
 // WorkoutScheduleCmd groups schedule subcommands.

--- a/internal/cmd/workouts_test.go
+++ b/internal/cmd/workouts_test.go
@@ -1253,3 +1253,182 @@ func TestWorkoutUpdate_ReadFileError(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// updateCaptureServer records the body of a PUT to /workout-service/workout/{id}.
+func updateCaptureServer(t *testing.T, captured *[]byte) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+		*captured = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestWorkoutUpdate_SetsWorkoutIDFromArgument(t *testing.T) {
+	var captured []byte
+	server := updateCaptureServer(t, &captured)
+
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	overrideNewClient(t, server)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	tmpFile := filepath.Join(t.TempDir(), "workout.json")
+	// A payload written for "workouts upload" carries no workoutId.
+	workoutJSON := `{"workoutName":"Tempo Run v2","sportType":{"sportTypeKey":"running"}}`
+	if err := os.WriteFile(tmpFile, []byte(workoutJSON), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "test@example.com")
+	cmd := &WorkoutUpdateCmd{ID: "42", File: tmpFile}
+	if err := cmd.Run(g); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var sent map[string]any
+	if err := json.Unmarshal(captured, &sent); err != nil {
+		t.Fatalf("unmarshal sent payload: %v", err)
+	}
+	if sent["workoutId"] != float64(42) {
+		t.Errorf("sent workoutId = %v, want 42", sent["workoutId"])
+	}
+	if sent["workoutName"] != "Tempo Run v2" {
+		t.Errorf("sent workoutName = %v, want Tempo Run v2", sent["workoutName"])
+	}
+	if strings.Contains(buf.String(), "instead") {
+		t.Errorf("expected no mismatch warning, got: %q", buf.String())
+	}
+}
+
+func TestWorkoutUpdate_WarnsOnMismatchedWorkoutID(t *testing.T) {
+	var captured []byte
+	server := updateCaptureServer(t, &captured)
+
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	overrideNewClient(t, server)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	tmpFile := filepath.Join(t.TempDir(), "workout.json")
+	workoutJSON := `{"workoutId":99,"workoutName":"Tempo Run v2"}`
+	if err := os.WriteFile(tmpFile, []byte(workoutJSON), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "test@example.com")
+	cmd := &WorkoutUpdateCmd{ID: "42", File: tmpFile}
+	if err := cmd.Run(g); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "workoutId 99") {
+		t.Errorf("expected mismatch warning, got: %q", buf.String())
+	}
+
+	// The ID argument wins: the request must target workout 42.
+	var sent map[string]any
+	if err := json.Unmarshal(captured, &sent); err != nil {
+		t.Fatalf("unmarshal sent payload: %v", err)
+	}
+	if sent["workoutId"] != float64(42) {
+		t.Errorf("sent workoutId = %v, want 42", sent["workoutId"])
+	}
+}
+
+func TestWorkoutUpdate_NonNumericID(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "workout.json")
+	if err := os.WriteFile(tmpFile, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "test@example.com")
+	cmd := &WorkoutUpdateCmd{ID: "not-an-id", File: tmpFile}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid workout ID") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWorkoutUpdate_NonObjectJSON(t *testing.T) {
+	store := newTestSecretsStore(t)
+	overrideLoadSecrets(t, store)
+	storeTestTokens(t, store, "test@example.com", testTokens())
+
+	tmpFile := filepath.Join(t.TempDir(), "workout.json")
+	if err := os.WriteFile(tmpFile, []byte(`[1,2,3]`), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	var buf bytes.Buffer
+	g := testGlobals(t, &buf, outfmt.Table, "test@example.com")
+	cmd := &WorkoutUpdateCmd{ID: "42", File: tmpFile}
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid JSON") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetWorkoutID(t *testing.T) {
+	tests := []struct {
+		name         string
+		payload      string
+		workoutID    string
+		wantReplaced string
+		wantErr      bool
+	}{
+		{name: "adds missing id", payload: `{"workoutName":"Run"}`, workoutID: "42"},
+		{name: "keeps matching id", payload: `{"workoutId":42}`, workoutID: "42"},
+		{name: "reports different id", payload: `{"workoutId":99}`, workoutID: "42", wantReplaced: "99"},
+		{name: "reports string id", payload: `{"workoutId":"99"}`, workoutID: "42", wantReplaced: "99"},
+		{name: "ignores null id", payload: `{"workoutId":null}`, workoutID: "42"},
+		{name: "rejects array", payload: `[1,2]`, workoutID: "42", wantErr: true},
+		{name: "rejects garbage", payload: `not json`, workoutID: "42", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, replaced, err := setWorkoutID([]byte(tt.payload), tt.workoutID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("setWorkoutID: %v", err)
+			}
+			if replaced != tt.wantReplaced {
+				t.Errorf("replaced = %q, want %q", replaced, tt.wantReplaced)
+			}
+
+			var fields map[string]any
+			if err := json.Unmarshal(got, &fields); err != nil {
+				t.Fatalf("unmarshal result: %v", err)
+			}
+			if fields["workoutId"] != float64(42) {
+				t.Errorf("workoutId = %v, want 42", fields["workoutId"])
+			}
+		})
+	}
+}

--- a/internal/e2e/workouts_write_test.go
+++ b/internal/e2e/workouts_write_test.go
@@ -15,18 +15,17 @@ import (
 
 const e2eWorkoutPrefix = "E2E_TEST_"
 
-// TestUploadWorkout uploads a minimal workout, verifies it appears in the
-// listing, downloads it as FIT, and deletes it via t.Cleanup.
-func TestUploadWorkout(t *testing.T) {
-	client := AuthenticatedClient(t)
-	ctx := context.Background()
+// workoutPayload builds a minimal running workout. workoutID is empty for an
+// upload and set to the target ID for an update: Garmin resolves the update by
+// the ID in the request path, and "gccli workouts update" writes the same ID
+// into the body before sending it.
+func workoutPayload(name string, distanceMeters int, workoutID string) json.RawMessage {
+	idField := ""
+	if workoutID != "" {
+		idField = fmt.Sprintf("\n\t\t\"workoutId\": %s,", workoutID)
+	}
 
-	// Safety-net: clean up orphaned E2E workouts from prior runs.
-	cleanupOrphanWorkouts(t, client)
-
-	// Create a minimal workout JSON with E2E_TEST_ prefix.
-	workoutName := fmt.Sprintf("%sWORKOUT_%d", e2eWorkoutPrefix, time.Now().UnixNano())
-	workoutJSON := json.RawMessage(fmt.Sprintf(`{
+	return json.RawMessage(fmt.Sprintf(`{%s
 		"workoutName": %q,
 		"sportType": {
 			"sportTypeId": 1,
@@ -49,17 +48,23 @@ func TestUploadWorkout(t *testing.T) {
 					"conditionTypeId": 2,
 					"conditionTypeKey": "distance"
 				},
-				"endConditionValue": 1000
+				"endConditionValue": %d
 			}]
 		}]
-	}`, workoutName))
+	}`, idField, name, distanceMeters))
+}
 
-	data, err := client.UploadWorkout(ctx, workoutJSON)
+// createE2EWorkout uploads a 1000 m workout and returns its ID. The workout is
+// deleted when the test finishes, even on failure.
+func createE2EWorkout(t *testing.T, client *garminapi.Client, name string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	data, err := client.UploadWorkout(ctx, workoutPayload(name, 1000, ""))
 	if err != nil {
 		t.Fatalf("UploadWorkout failed: %v", err)
 	}
 
-	// Extract the created workout ID.
 	var created map[string]any
 	if err := json.Unmarshal(data, &created); err != nil {
 		t.Fatalf("unmarshal created workout: %v", err)
@@ -69,9 +74,8 @@ func TestUploadWorkout(t *testing.T) {
 	if workoutID == "" || workoutID == "0" {
 		t.Fatalf("expected valid workoutId, got %q", workoutID)
 	}
-	t.Logf("Created workout %s with name %q", workoutID, workoutName)
+	t.Logf("Created workout %s with name %q", workoutID, name)
 
-	// Register cleanup to delete the workout — runs even on test failure.
 	RegisterCleanup(t, func() {
 		if delErr := client.DeleteWorkout(context.Background(), workoutID); delErr != nil {
 			t.Logf("WARNING: failed to clean up workout %s: %v", workoutID, delErr)
@@ -79,6 +83,21 @@ func TestUploadWorkout(t *testing.T) {
 			t.Logf("Cleaned up workout %s", workoutID)
 		}
 	})
+
+	return workoutID
+}
+
+// TestUploadWorkout uploads a minimal workout, verifies it appears in the
+// listing, downloads it as FIT, and deletes it via t.Cleanup.
+func TestUploadWorkout(t *testing.T) {
+	client := AuthenticatedClient(t)
+	ctx := context.Background()
+
+	// Safety-net: clean up orphaned E2E workouts from prior runs.
+	cleanupOrphanWorkouts(t, client)
+
+	workoutName := fmt.Sprintf("%sWORKOUT_%d", e2eWorkoutPrefix, time.Now().UnixNano())
+	workoutID := createE2EWorkout(t, client, workoutName)
 
 	// Verify the workout appears in the listing.
 	found := findWorkoutByID(t, client, workoutID)
@@ -97,6 +116,168 @@ func TestUploadWorkout(t *testing.T) {
 	t.Logf("Downloaded workout %s as FIT: %d bytes", workoutID, len(fitData))
 
 	// The t.Cleanup handler will delete the workout.
+}
+
+// TestUpdateWorkout replaces an uploaded workout and verifies that the changed
+// payload lands on the server while the workout keeps its ID.
+func TestUpdateWorkout(t *testing.T) {
+	client := AuthenticatedClient(t)
+	ctx := context.Background()
+
+	workoutName := fmt.Sprintf("%sUPDATE_%d", e2eWorkoutPrefix, time.Now().UnixNano())
+	workoutID := createE2EWorkout(t, client, workoutName)
+
+	updatedName := workoutName + "_V2"
+	data, err := client.UpdateWorkout(ctx, workoutID, workoutPayload(updatedName, 2000, workoutID))
+	if err != nil {
+		t.Fatalf("UpdateWorkout(%s) failed: %v", workoutID, err)
+	}
+
+	// Garmin answers the PUT with an empty body. Older behaviour echoed the
+	// workout back, so check the ID whenever there is something to check.
+	if len(data) == 0 {
+		t.Logf("UpdateWorkout(%s) returned an empty body", workoutID)
+	} else {
+		var updated map[string]any
+		if err := json.Unmarshal(data, &updated); err != nil {
+			t.Fatalf("unmarshal update response: %v", err)
+		}
+		if got := formatID(updated["workoutId"]); got != workoutID {
+			t.Errorf("update response workoutId = %q, want %q", got, workoutID)
+		}
+	}
+
+	// Read the workout back: an update is a full replace, so both the name and
+	// the step must reflect the new payload under the original ID.
+	stored := fetchWorkout(t, client, workoutID)
+	if got := formatID(stored["workoutId"]); got != workoutID {
+		t.Errorf("stored workoutId = %q, want %q", got, workoutID)
+	}
+	if got, _ := stored["workoutName"].(string); got != updatedName {
+		t.Errorf("stored workoutName = %q, want %q", got, updatedName)
+	}
+	if got, ok := firstStepDistance(stored); !ok {
+		t.Error("stored workout has no first step endConditionValue")
+	} else if got != 2000 {
+		t.Errorf("stored endConditionValue = %v, want 2000", got)
+	}
+
+	// The update must not have created a second workout.
+	if !findWorkoutByID(t, client, workoutID) {
+		t.Errorf("updated workout %s not found in GetWorkouts listing", workoutID)
+	}
+	t.Logf("Updated workout %s in place", workoutID)
+}
+
+// TestUpdateWorkoutKeepsSchedule verifies the reason update exists: the
+// calendar entry survives. Delete plus upload would drop the schedule and hand
+// out a new workout ID.
+func TestUpdateWorkoutKeepsSchedule(t *testing.T) {
+	client := AuthenticatedClient(t)
+	ctx := context.Background()
+
+	workoutName := fmt.Sprintf("%sSCHEDULED_%d", e2eWorkoutPrefix, time.Now().UnixNano())
+	workoutID := createE2EWorkout(t, client, workoutName)
+
+	date := time.Now().AddDate(0, 0, 14).Format("2006-01-02")
+	if _, err := client.ScheduleWorkout(ctx, workoutID, date); err != nil {
+		t.Fatalf("ScheduleWorkout(%s, %s) failed: %v", workoutID, date, err)
+	}
+
+	scheduleID := findScheduleID(t, client, workoutID, date)
+	if scheduleID == "" {
+		t.Fatalf("workout %s not on the calendar for %s after scheduling", workoutID, date)
+	}
+	t.Logf("Scheduled workout %s on %s (schedule %s)", workoutID, date, scheduleID)
+
+	// Runs before the workout delete registered above (t.Cleanup is LIFO).
+	RegisterCleanup(t, func() {
+		if err := client.UnscheduleWorkout(context.Background(), scheduleID); err != nil {
+			t.Logf("WARNING: failed to remove schedule %s: %v", scheduleID, err)
+		} else {
+			t.Logf("Removed schedule %s", scheduleID)
+		}
+	})
+
+	updatedName := workoutName + "_V2"
+	if _, err := client.UpdateWorkout(ctx, workoutID, workoutPayload(updatedName, 2000, workoutID)); err != nil {
+		t.Fatalf("UpdateWorkout(%s) failed: %v", workoutID, err)
+	}
+
+	if got := findScheduleID(t, client, workoutID, date); got != scheduleID {
+		t.Errorf("schedule ID for workout %s on %s = %q after update, want %q", workoutID, date, got, scheduleID)
+	}
+}
+
+// fetchWorkout reads a single workout from the server.
+func fetchWorkout(t *testing.T, client *garminapi.Client, workoutID string) map[string]any {
+	t.Helper()
+
+	data, err := client.GetWorkout(context.Background(), workoutID)
+	if err != nil {
+		t.Fatalf("GetWorkout(%s) failed: %v", workoutID, err)
+	}
+
+	var workout map[string]any
+	if err := json.Unmarshal(data, &workout); err != nil {
+		t.Fatalf("unmarshal workout %s: %v", workoutID, err)
+	}
+	return workout
+}
+
+// firstStepDistance returns the endConditionValue of the first step of the
+// first segment.
+func firstStepDistance(workout map[string]any) (float64, bool) {
+	segments, ok := workout["workoutSegments"].([]any)
+	if !ok || len(segments) == 0 {
+		return 0, false
+	}
+	segment, ok := segments[0].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	steps, ok := segment["workoutSteps"].([]any)
+	if !ok || len(steps) == 0 {
+		return 0, false
+	}
+	step, ok := steps[0].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	value, ok := step["endConditionValue"].(float64)
+	return value, ok
+}
+
+// findScheduleID returns the calendar schedule ID for a workout on a date, or
+// an empty string when the workout is not scheduled that day.
+func findScheduleID(t *testing.T, client *garminapi.Client, workoutID, date string) string {
+	t.Helper()
+
+	data, err := client.GetCalendarWeek(context.Background(), date)
+	if err != nil {
+		t.Fatalf("GetCalendarWeek(%s) failed: %v", date, err)
+	}
+
+	var calendar struct {
+		CalendarItems []map[string]any `json:"calendarItems"`
+	}
+	if err := json.Unmarshal(data, &calendar); err != nil {
+		t.Fatalf("parse calendar for %s: %v", date, err)
+	}
+
+	for _, item := range calendar.CalendarItems {
+		if itemType, _ := item["itemType"].(string); itemType != "workout" {
+			continue
+		}
+		if itemDate, _ := item["date"].(string); itemDate != date {
+			continue
+		}
+		if formatID(item["workoutId"]) != workoutID {
+			continue
+		}
+		return formatID(item["id"])
+	}
+	return ""
 }
 
 // findWorkoutByID searches recent workouts for one with the given ID.

--- a/skills/gccli/SKILL.md
+++ b/skills/gccli/SKILL.md
@@ -202,3 +202,4 @@ Notes
 - Confirm before deleting activities/workouts (or use `--force`).
 - Download formats: FIT (default), GPX, TCX, KML, CSV.
 - Workout step format: `type:duration[@target:low-high]` — types: warmup, run, recovery, cooldown; targets: pace (min:sec), hr (bpm), power (watts), cadence.
+- `workouts update` replaces the whole workout, so build the file from `gccli workouts detail <id>` and edit it. `workoutId` is set from the ID argument, so an `upload` payload works unchanged.


### PR DESCRIPTION
Follow-up to #60.

## Problem

`workouts update` passed the file bytes to `PUT /workout-service/workout/{id}` unchanged, so the ID in the path and the `workoutId` in the body were independent:

- A payload built from the README's documented "Workout JSON structure" has no `workoutId` at all. Only a payload fetched back from the server carries one, which is why the manual verification on #60 did not hit this.
- A file copied from another workout names that other workout in the body while the command line names a different one.

## Fix

The ID argument is the source of truth.

- It is parsed as a number up front, so a typo fails with `invalid workout ID` instead of a 404 from Garmin.
- `setWorkoutID` writes it into the payload before the request, so a file written for `workouts upload` now works unchanged.
- If the file already carries a different `workoutId`, gccli warns which workout it is actually updating rather than silently picking one.
- The payload must be a JSON object. `json.Valid` accepted arrays and bare scalars; the error now names the file.

## Docs

CONTRIBUTING asks for the features list and the command examples in all three sources. #60 updated the command reference everywhere but not the two summary spots:

- `README.md` features list
- `docs/index.html` Workouts feature card

Both mention update now. All three also say what was missing before: PUT is a full replace, not a patch, so the file has to be the complete workout, and `gccli workouts detail <id>` is where to get one.

## Tests

5 new tests: the injected ID reaches the wire, the mismatch warning fires and the argument still wins, non-numeric ID, non-object JSON, plus a table test for `setWorkoutID` covering missing, matching, differing, string-typed and null IDs.

`make fmt-check` and `make test` pass. `make lint` still fails on a clean `main` here for the reason described in #60 (local golangci-lint against the Go 1.25 toolchain), unrelated to this change.

## E2E

`internal/e2e/workouts_write_test.go` now covers update against the live API:

- `TestUpdateWorkout` uploads a workout, replaces it with a changed payload, and reads it back. Name and step distance change, the workout ID does not, and no second workout shows up in the listing.
- `TestUpdateWorkoutKeepsSchedule` schedules a workout two weeks out, updates it, and checks that the calendar entry is still there under the same schedule ID. That is the reason update exists over delete plus upload.

The upload payload and the create-plus-cleanup block moved into `workoutPayload` and `createE2EWorkout`, so `TestUploadWorkout` shares them. Both new tests clean up after themselves: the schedule is removed before the workout is deleted.

One thing the run turned up: Garmin answers `PUT /workout-service/workout/{id}` with an **empty body**. The unit tests mock a server that echoes the workout back, which is not what the real API does. Consequence: `gccli workouts update <id> <file> --json` prints `null` today. The update itself works, the read-back in the test confirms it. Worth a follow-up so `--json` returns something usable.

All three e2e tests pass against a real account.
