### PR TITLE
test(workouts): mock the real empty PUT response for update

### DIFF
--- a/internal/cmd/workouts_test.go
+++ b/internal/cmd/workouts_test.go
@@ -40,11 +40,8 @@ func workoutsTestServer(t *testing.T) *httptest.Server {
 				http.Error(w, "bad json", http.StatusBadRequest)
 				return
 			}
-			// The workout keeps its original ID on update.
-			payload["workoutId"] = float64(42)
-			resp, _ := json.Marshal(payload)
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write(resp)
+			// Garmin answers an update with 204 and no body.
+			w.WriteHeader(http.StatusNoContent)
 		case http.MethodDelete:
 			w.WriteHeader(http.StatusNoContent)
 		default:
@@ -1268,8 +1265,7 @@ func updateCaptureServer(t *testing.T, captured *[]byte) *httptest.Server {
 			return
 		}
 		*captured = body
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(body)
+		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(server.Close)
 	return server

--- a/internal/garminapi/workouts_test.go
+++ b/internal/garminapi/workouts_test.go
@@ -442,23 +442,22 @@ func TestUpdateWorkout_Success(t *testing.T) {
 		if payload["workoutName"] != "Updated Workout" {
 			t.Errorf("workoutName = %v, want Updated Workout", payload["workoutName"])
 		}
+		// The body must name the same workout as the path.
+		if payload["workoutId"] != float64(42) {
+			t.Errorf("workoutId = %v, want 42", payload["workoutId"])
+		}
 
-		_, _ = w.Write([]byte(`{"workoutId":42,"workoutName":"Updated Workout"}`))
+		// Garmin answers an update with 204 and no body.
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	_, client := testServer(t, handler)
-	data, err := client.UpdateWorkout(context.Background(), "42", json.RawMessage(`{"workoutName":"Updated Workout"}`))
+	data, err := client.UpdateWorkout(context.Background(), "42", json.RawMessage(`{"workoutId":42,"workoutName":"Updated Workout"}`))
 	if err != nil {
 		t.Fatalf("UpdateWorkout: %v", err)
 	}
-
-	var got map[string]any
-	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
-	}
-	// The workout must keep its original ID so schedules stay intact.
-	if got["workoutId"] != float64(42) {
-		t.Errorf("workoutId = %v, want 42", got["workoutId"])
+	if len(data) != 0 {
+		t.Errorf("data = %s, want empty response", data)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #61.

## Problem

Both mock servers for `PUT /workout-service/workout/{id}` echoed the payload back with `workoutId` filled in, and `TestUpdateWorkout_Success` asserted that echo. The e2e run added in #61 showed Garmin answers the update with **204 and no body**, so the unit tests were pinning a response the real API never sends.

## Fix

- `workoutsTestServer` and `updateCaptureServer` in `internal/cmd/workouts_test.go` return 204 with no body. Both still parse the request body, so a malformed payload is still rejected.
- `TestUpdateWorkout_Success` in `internal/garminapi/workouts_test.go` now asserts what the client can actually observe: the request carries the `workoutId` that the path names, and `UpdateWorkout` hands back an empty response.

The tests that matter for #61, the injected ID reaching the wire and the mismatch warning, are unchanged. They read the captured request, not the response.

## Still open

With an empty body, `gccli workouts update <id> <file> --json` prints `null`. That is existing behaviour and not touched here. Making `--json` return something usable, for example `{"workoutId": <id>}`, is a separate change.

`make fmt-check` and `make test` pass.